### PR TITLE
Add Spike A kit: manual end-to-end path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.go text eol=lf

--- a/spike/a/01-fetch.ps1
+++ b/spike/a/01-fetch.ps1
@@ -1,0 +1,25 @@
+# Spike A step 1: download + verify the Alpine rootfs, download the Docker static bundle.
+$ErrorActionPreference = 'Stop'
+$dl = Join-Path $PSScriptRoot 'dl'
+New-Item -ItemType Directory -Force $dl | Out-Null
+
+$alpine    = 'alpine-minirootfs-3.24.1-x86_64.tar.gz'
+$alpineUrl = "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/$alpine"
+$docker    = 'docker-29.7.2.tgz'
+$dockerUrl = "https://download.docker.com/linux/static/stable/x86_64/$docker"
+
+Write-Host "Fetching $alpine ..."
+Invoke-WebRequest $alpineUrl -OutFile (Join-Path $dl $alpine)
+Invoke-WebRequest "$alpineUrl.sha256" -OutFile (Join-Path $dl "$alpine.sha256")
+$expected = ((Get-Content (Join-Path $dl "$alpine.sha256")) -split '\s+')[0].ToLower()
+$actual   = (Get-FileHash (Join-Path $dl $alpine) -Algorithm SHA256).Hash.ToLower()
+if ($actual -ne $expected) { throw "Alpine checksum mismatch: expected $expected got $actual" }
+Write-Host "  sha256 OK: $actual"
+
+Write-Host "Fetching $docker ..."
+Invoke-WebRequest $dockerUrl -OutFile (Join-Path $dl $docker)
+# download.docker.com publishes no checksums for static bundles; record what we got.
+$dockerHash = (Get-FileHash (Join-Path $dl $docker) -Algorithm SHA256).Hash.ToLower()
+Write-Host "  sha256 (record in issue #2): $dockerHash"
+
+Write-Host "Done. Next: .\02-import.ps1"

--- a/spike/a/02-import.ps1
+++ b/spike/a/02-import.ps1
@@ -1,0 +1,22 @@
+# Spike A step 2: import the distro and provision dockerd inside it.
+$ErrorActionPreference = 'Stop'
+$dl     = Join-Path $PSScriptRoot 'dl'
+$alpine = Join-Path $dl 'alpine-minirootfs-3.24.1-x86_64.tar.gz'
+$tgz    = Join-Path $dl 'docker-29.7.2.tgz'
+$vhdDir = Join-Path $env:LOCALAPPDATA 'hawser-spike'
+
+if ((wsl --list --quiet) -contains 'hawser-spike') { throw "distro 'hawser-spike' already exists - run 99-cleanup.ps1 first" }
+
+Write-Host "Importing hawser-spike ..."
+New-Item -ItemType Directory -Force $vhdDir | Out-Null
+wsl --import hawser-spike $vhdDir $alpine --version 2
+if ($LASTEXITCODE -ne 0) { throw "wsl --import failed" }
+
+# Translate Windows paths for use inside the distro, then run the setup script.
+$setupWsl = (wsl -d hawser-spike --exec wslpath -a ($PSScriptRoot + '\03-setup.sh')).Trim()
+$tgzWsl   = (wsl -d hawser-spike --exec wslpath -a $tgz).Trim()
+Write-Host "Running 03-setup.sh inside the distro ..."
+wsl -d hawser-spike -u root --exec sh $setupWsl $tgzWsl
+if ($LASTEXITCODE -ne 0) { throw "03-setup.sh failed" }
+
+Write-Host "Done. Next: .\04-start-engine.ps1"

--- a/spike/a/03-setup.sh
+++ b/spike/a/03-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Spike A step 3 (runs INSIDE the hawser-spike distro, as root, invoked by 02-import.ps1).
+# $1 = /mnt/... path to docker-29.7.2.tgz
+set -eu
+TGZ="$1"
+
+apk add --no-cache socat iptables ip6tables iproute2 ca-certificates
+
+tar -xzf "$TGZ" -C /usr/local/bin --strip-components=1
+mkdir -p /etc/docker /var/log
+cat > /etc/docker/daemon.json <<'EOF'
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-files": "3" }
+}
+EOF
+
+echo "setup OK: $(dockerd --version)"

--- a/spike/a/04-start-engine.ps1
+++ b/spike/a/04-start-engine.ps1
@@ -1,0 +1,20 @@
+# Spike A step 4: start dockerd hidden, wait for its socket.
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Starting dockerd in hawser-spike ..."
+Start-Process -WindowStyle Hidden wsl.exe -ArgumentList '-d','hawser-spike','-u','root','--','sh','-c','dockerd >/var/log/dockerd.log 2>&1'
+
+$deadline = (Get-Date).AddSeconds(30)
+do {
+    Start-Sleep -Milliseconds 500
+    wsl -d hawser-spike -u root --exec test -S /var/run/docker.sock
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "docker.sock is up."
+        Write-Host "Next: cd relay; go mod tidy; go build; .\relay.exe"
+        exit 0
+    }
+} while ((Get-Date) -lt $deadline)
+
+Write-Host "Socket never appeared. Log tail:"
+wsl -d hawser-spike -u root --exec tail -50 /var/log/dockerd.log
+exit 1

--- a/spike/a/05-verify.ps1
+++ b/spike/a/05-verify.ps1
@@ -1,0 +1,28 @@
+# Spike A step 5: automated checks against the relay. relay.exe must be running.
+$ErrorActionPreference = 'Stop'
+$env:DOCKER_HOST = 'npipe:////./pipe/hawser_spike'
+
+Write-Host "== docker version =="
+docker version
+if ($LASTEXITCODE -ne 0) { throw "docker version failed - is relay.exe running?" }
+
+Write-Host "`n== hello-world =="
+docker run --rm hello-world
+if ($LASTEXITCODE -ne 0) { throw "hello-world failed" }
+
+Write-Host "`n== latency: 10x docker version =="
+$times = 1..10 | ForEach-Object { (Measure-Command { docker version *> $null }).TotalMilliseconds }
+$m = $times | Measure-Object -Average -Minimum -Maximum
+Write-Host ("avg {0:N0} ms  min {1:N0} ms  max {2:N0} ms   (record in issue #2)" -f $m.Average, $m.Minimum, $m.Maximum)
+
+Write-Host "`n== binary safety: docker save x2, hashes must match =="
+docker pull alpine:latest | Out-Null
+$t1 = Join-Path $env:TEMP 'spike-save-1.tar'; $t2 = Join-Path $env:TEMP 'spike-save-2.tar'
+docker save alpine:latest -o $t1
+docker save alpine:latest -o $t2
+$h1 = (Get-FileHash $t1 -Algorithm SHA256).Hash; $h2 = (Get-FileHash $t2 -Algorithm SHA256).Hash
+Remove-Item $t1, $t2 -Force
+if ($h1 -ne $h2) { throw "docker save not deterministic across the relay: $h1 vs $h2" }
+Write-Host "identical: $h1"
+
+Write-Host "`nAutomated checks PASSED. Now the manual list in README.md (exec -it, logs -f, build, coexistence)."

--- a/spike/a/99-cleanup.ps1
+++ b/spike/a/99-cleanup.ps1
@@ -1,0 +1,10 @@
+# Spike A cleanup: remove every trace of the spike.
+$ErrorActionPreference = 'Continue'
+
+wsl --terminate hawser-spike 2>$null
+wsl --unregister hawser-spike 2>$null
+Remove-Item -Recurse -Force (Join-Path $env:LOCALAPPDATA 'hawser-spike') -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force (Join-Path $PSScriptRoot 'dl') -ErrorAction SilentlyContinue
+Remove-Item -Force (Join-Path $PSScriptRoot 'relay\relay.exe'), (Join-Path $PSScriptRoot 'relay\go.sum') -ErrorAction SilentlyContinue
+
+Write-Host "hawser-spike distro unregistered, downloads and binaries removed."

--- a/spike/a/README.md
+++ b/spike/a/README.md
@@ -1,0 +1,53 @@
+# Spike A — manual end-to-end path (issue #2)
+
+Throwaway kit. Proves: Alpine + static dockerd in a dedicated WSL2 distro, reachable from
+stock `docker.exe` through a named pipe relayed over `wsl.exe` stdio. **Nothing here is
+product code** — it exists to produce the measurements listed at the bottom, recorded in
+issue #2, then `99-cleanup.ps1` erases all trace.
+
+Pins: Alpine minirootfs **3.24.1** · Docker static **29.7.2** · pipe `\\.\pipe\hawser_spike`
+(never `docker_engine` — Docker Desktop owns that here, and coexistence is part of the test).
+
+## Prerequisites
+
+- WSL2 working (`wsl --status`)
+- Go on Windows: `winget install GoLang.Go` (new terminal afterwards so PATH updates)
+- Any `docker.exe` on PATH (Docker Desktop's is fine — we point it at our pipe via `DOCKER_HOST`)
+
+## Run order
+
+```powershell
+.\01-fetch.ps1        # download + verify alpine rootfs, download docker static tgz
+.\02-import.ps1       # wsl --import hawser-spike, run 03-setup.sh inside it
+.\04-start-engine.ps1 # start dockerd (hidden), wait for the socket
+cd relay; go mod tidy; go build; .\relay.exe   # leave running in this terminal
+# new terminal:
+.\05-verify.ps1       # automated checks + latency numbers
+# then the manual checks below, then:
+.\99-cleanup.ps1      # unregister distro, delete downloads
+```
+
+## What to record in issue #2
+
+Automated (05-verify prints these):
+- [ ] `docker version` round-trip latency: avg / min / max over 10 runs
+- [ ] `docker run --rm hello-world` end-to-end
+- [ ] binary safety: `docker save` twice → identical sha256
+- [ ] per-connection socat spawn time (relay.exe log lines)
+
+Manual:
+- [ ] `docker run -it --rm alpine sh` — interactive shell usable, Ctrl-D exits cleanly (hijack)
+- [ ] `docker exec -it <ctr> sh` into a running container
+- [ ] `docker logs -f <ctr>` streams; Ctrl-C detaches without killing the container
+- [ ] half-close: `docker build -t spike-test .` with a small context dir (client sends tar,
+      half-closes, then waits for the build stream back)
+- [ ] coexistence: switch back to Desktop's context — `docker context use desktop-linux; docker ps`
+      still works while relay.exe is running
+- [ ] gotchas: anything about wsl.exe stdio (buffering, CRLF, exit codes), cgroups,
+      iptables, DNS inside the spike distro
+
+## GO/NO-GO
+
+GO = all of the above pass or have understood workarounds. NO-GO = the wsl.exe stdio
+relay is not binary-safe or hijacked streams can't survive it — that would force the
+vsock agent forward from v0.2 into v0.1 (or a rethink).

--- a/spike/a/relay/go.mod
+++ b/spike/a/relay/go.mod
@@ -1,0 +1,5 @@
+module github.com/zcsizmadia/hawser/spike/a/relay
+
+go 1.22
+
+require github.com/Microsoft/go-winio v0.6.2

--- a/spike/a/relay/main.go
+++ b/spike/a/relay/main.go
@@ -1,0 +1,71 @@
+// Spike A throwaway relay: \\.\pipe\hawser_spike -> hawser-spike distro's docker.sock,
+// one wsl.exe+socat process per connection. Measures what issue #2 asks for; not product code.
+package main
+
+import (
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+const pipeName = `\\.\pipe\hawser_spike`
+
+func main() {
+	l, err := winio.ListenPipe(pipeName, nil)
+	if err != nil {
+		log.Fatalf("listen %s: %v", pipeName, err)
+	}
+	log.Printf("relaying %s -> hawser-spike /var/run/docker.sock", pipeName)
+	log.Printf(`try: $env:DOCKER_HOST = "npipe:////./pipe/hawser_spike"; docker version`)
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			log.Fatalf("accept: %v", err)
+		}
+		go handle(c)
+	}
+}
+
+func handle(c net.Conn) {
+	start := time.Now()
+	defer c.Close()
+
+	cmd := exec.Command("wsl.exe", "-d", "hawser-spike", "-u", "root", "--exec",
+		"socat", "STDIO", "UNIX-CONNECT:/var/run/docker.sock")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		log.Printf("stdin pipe: %v", err)
+		return
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Printf("stdout pipe: %v", err)
+		return
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Printf("spawn wsl.exe: %v", err)
+		return
+	}
+	log.Printf("conn open: relay process up in %v", time.Since(start))
+
+	// client -> engine; when the client half-closes, propagate EOF via stdin.
+	go func() {
+		io.Copy(stdin, c)
+		stdin.Close()
+	}()
+
+	// engine -> client; when the engine is done, half-close our write side
+	// so the client can still drain (hijacked streams rely on this).
+	io.Copy(c, stdout)
+	if cw, ok := c.(interface{ CloseWrite() error }); ok {
+		cw.CloseWrite()
+	}
+	cmd.Wait()
+	log.Printf("conn closed after %v", time.Since(start))
+}


### PR DESCRIPTION
Throwaway kit for Spike A (#2) — the GO/NO-GO gate proving the whole architecture by hand:

- `01-fetch.ps1` — Alpine minirootfs 3.24.1 (sha256-verified) + Docker static 29.7.2
- `02-import.ps1` / `03-setup.sh` — import `hawser-spike` distro, provision static dockerd + socat
- `04-start-engine.ps1` — start dockerd hidden, wait for the socket
- `relay/` — go-winio pipe listener at `\\.\pipe\hawser_spike`, per-connection `wsl.exe --exec socat` relay with half-close handling and latency logging
- `05-verify.ps1` — docker version / hello-world / 10x latency stats / `docker save` binary-safety check
- `99-cleanup.ps1` — remove every trace
- `.gitattributes` — keep `.sh`/`.go` LF on Windows checkouts (setup script runs inside the distro)

Measurement checklist in the README mirrors what #2 asks to record. No CI checks exist yet (that lands with #4), so merging on creation per the agreed flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)