### PR TITLE
Repo skeleton: Go module, CLI stub, wsl interface, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build & test (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: gofmt
+        shell: pwsh
+        run: |
+          $bad = gofmt -l .
+          if ($bad) { Write-Host "gofmt needed:"; $bad; exit 1 }
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test ./...
+
+      # The Spike A relay is a separate throwaway module — keep it compiling
+      # until the real pipeproxy replaces it, then this step goes away.
+      - name: build spike relay
+        working-directory: spike/a/relay
+        run: |
+          go mod tidy
+          go build ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Hawser
+
+> **hawser** *(n.)* — the heavy line that moors a ship to the dock. It holds fast.
+
+A minimal, invisible way to run the upstream open source **Docker Engine on Windows** via WSL2.
+No license fees, no Electron, no Kubernetes — install once, `docker ps` works forever, on
+laptops and CI runners alike.
+
+**Status: pre-alpha.** Nothing installable yet — the architecture spikes are in progress.
+Read [PLAN.md](PLAN.md) for the strategy and [ROADMAP.md](ROADMAP.md) for the schedule;
+the [issue tracker](https://github.com/zcsizmadia/hawser/issues) is the live state.
+
+## What it will be
+
+- Upstream Docker Engine (Linux containers) in a dedicated WSL2 distro — the real API, byte for byte
+- A named-pipe bridge so stock `docker.exe`, compose, buildx, Testcontainers, and IDE
+  integrations work unmodified
+- A real Windows service: boot start, crash recovery, sleep/resume survival, no login required
+- Headless CI installs, version pinning as a contract, `doctor` for the WSL/VPN quirk zoo
+- A single Go binary under 15 MB, no telemetry
+
+## What it will never be
+
+Windows containers, Kubernetes, or a management GUI. Because Hawser serves the standard
+Docker API, existing frontends (Portainer, lazydocker, VS Code) already work against it.
+
+## License
+
+[Apache-2.0](LICENSE). Docker and the Docker logo are trademarks of Docker, Inc.
+Hawser is not affiliated with or endorsed by Docker, Inc.

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -1,0 +1,20 @@
+// Command hawser runs the upstream Docker Engine on Windows via WSL2:
+// a provisioner, a named-pipe bridge, and a supervisor in one binary.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// version is stamped by the release build (-ldflags "-X main.version=...").
+var version = "dev"
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		fmt.Printf("hawser %s\n", version)
+		return
+	}
+	fmt.Fprintln(os.Stderr, "hawser: pre-alpha — see PLAN.md and ROADMAP.md")
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/zcsizmadia/hawser
+
+go 1.23

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -1,0 +1,27 @@
+// Package wsl hides every wsl.exe invocation behind an interface so the rest
+// of the codebase is testable anywhere; only the e2e suite needs real WSL2.
+package wsl
+
+import "context"
+
+// WSL is the seam between hawser and the wsl.exe binary. Production code
+// depends on this interface, never on exec.Command directly.
+type WSL interface {
+	// Status reports whether WSL2 and virtualization are available.
+	Status(ctx context.Context) (Status, error)
+	// Import registers a distro from a rootfs tarball (wsl --import, version 2).
+	Import(ctx context.Context, distro, installDir, rootfsPath string) error
+	// Unregister removes a distro and its VHDX (wsl --unregister).
+	Unregister(ctx context.Context, distro string) error
+	// Terminate stops a running distro (wsl --terminate).
+	Terminate(ctx context.Context, distro string) error
+	// List returns registered distro names (wsl --list --quiet).
+	List(ctx context.Context) ([]string, error)
+}
+
+// Status describes the host's WSL capability, from wsl --status and wsl --version.
+type Status struct {
+	Installed      bool
+	DefaultVersion int
+	Version        string // WSL release, e.g. "2.7.8.0"
+}

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -1,0 +1,42 @@
+package wsl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// fake proves the interface is implementable without wsl.exe — the pattern
+// every consumer test will use.
+type fake struct{ distros []string }
+
+func (f *fake) Status(context.Context) (wsl.Status, error) {
+	return wsl.Status{Installed: true, DefaultVersion: 2, Version: "2.7.8.0"}, nil
+}
+func (f *fake) Import(_ context.Context, distro, _, _ string) error {
+	f.distros = append(f.distros, distro)
+	return nil
+}
+func (f *fake) Unregister(context.Context, string) error { return nil }
+func (f *fake) Terminate(context.Context, string) error  { return nil }
+func (f *fake) List(context.Context) ([]string, error)   { return f.distros, nil }
+
+var _ wsl.WSL = (*fake)(nil)
+
+func TestFakeRoundTrip(t *testing.T) {
+	var w wsl.WSL = &fake{}
+	ctx := context.Background()
+
+	st, err := w.Status(ctx)
+	if err != nil || !st.Installed || st.DefaultVersion != 2 {
+		t.Fatalf("Status() = %+v, %v", st, err)
+	}
+	if err := w.Import(ctx, "hawser-engine", `C:\data`, `C:\rootfs.tar`); err != nil {
+		t.Fatalf("Import() = %v", err)
+	}
+	got, err := w.List(ctx)
+	if err != nil || len(got) != 1 || got[0] != "hawser-engine" {
+		t.Fatalf("List() = %v, %v", got, err)
+	}
+}


### PR DESCRIPTION
Closes #4.

- Go module + `cmd/hawser` stub (version via ldflags)
- `internal/wsl`: the mockable seam PLAN §08 requires — production code depends on the interface, never on `exec.Command` directly; fake-backed test runs anywhere
- CI (`windows-latest`): gofmt / vet / build / test + keeps the Spike A relay compiling
- Apache-2.0 LICENSE, README (pre-alpha, honest scope, trademark disclaimer)

Deliberate deviation from the issue checklist: empty `internal/*` packages are **not** stubbed — each is created when its first real code lands, so the tree never lies about what exists.

First PR with CI — merging only after green, per the agreed flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)