### PR TITLE
Rootfs build pipeline: engine from source, SBOM, CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Lint staged shell scripts before they can reach CI.
+# Enable once per clone:  git config core.hooksPath .githooks
+# Bypass deliberately:    git commit --no-verify
+set -eu
+
+staged=$(git diff --cached --name-only --diff-filter=ACM | grep '\.sh$' || true)
+[ -z "$staged" ] && exit 0
+
+# -x follows `source=` directives, -P SCRIPTDIR resolves them next to each script.
+run_shellcheck() {
+    # scripts/install-tools.ps1 drops a copy here when it isn't on PATH.
+    local_sc="${LOCALAPPDATA:-}/hawser-tools/shellcheck.exe"
+    if command -v shellcheck >/dev/null 2>&1; then
+        shellcheck -x -P SCRIPTDIR "$@"
+    elif [ -x "$local_sc" ]; then
+        "$local_sc" -x -P SCRIPTDIR "$@"
+    elif command -v docker >/dev/null 2>&1; then
+        docker run --rm -v "$(pwd):/mnt" -w /mnt koalaman/shellcheck:stable -x -P SCRIPTDIR "$@"
+    else
+        echo "pre-commit: no shellcheck and no docker - skipping shell lint" >&2
+        return 0
+    fi
+}
+
+echo "pre-commit: shellcheck"
+# shellcheck disable=SC2086  # word splitting is how we pass the file list
+if ! run_shellcheck $staged; then
+    echo "pre-commit: shellcheck failed - fix, or commit with --no-verify" >&2
+    exit 1
+fi

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -19,10 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # -x follows the `source=` directives into versions.env, which isn't a
-      # .sh file and so isn't in the argument list.
+      # Same invocation as scripts/lint.ps1 and the pre-commit hook: -x follows
+      # `source=` directives, -P SCRIPTDIR resolves them next to each script
+      # (versions.env sits beside build.sh, not in the working directory).
       - name: shellcheck
-        run: shellcheck -x guest/rootfs/*.sh spike/a/*.sh
+        run: shellcheck -x -P SCRIPTDIR guest/rootfs/*.sh spike/a/*.sh
 
   build:
     name: build rootfs

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -1,0 +1,61 @@
+name: rootfs
+
+on:
+  push:
+    branches: [main]
+    paths: ['guest/rootfs/**', '.github/workflows/rootfs.yml']
+  pull_request:
+    paths: ['guest/rootfs/**', '.github/workflows/rootfs.yml']
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        run: shellcheck guest/rootfs/*.sh spike/a/*.sh
+
+  build:
+    name: build rootfs
+    runs-on: ubuntu-latest
+    # The from-source engine build takes ~30 min; on PRs it only runs when the
+    # rootfs itself changed (see paths filter), which is what we want to gate.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build
+        run: ./guest/rootfs/build.sh "$GITHUB_WORKSPACE/out"
+
+      - name: smoke test the rootfs
+        run: ./guest/rootfs/smoke-test.sh "$GITHUB_WORKSPACE/out"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hawser-rootfs
+          path: out/
+          retention-days: 14
+
+  publish:
+    name: attach to release
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: hawser-rootfs
+          path: out
+      - name: upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" out/* --clobber

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -19,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # -x follows the `source=` directives into versions.env, which isn't a
+      # .sh file and so isn't in the argument list.
       - name: shellcheck
-        run: shellcheck guest/rootfs/*.sh spike/a/*.sh
+        run: shellcheck -x guest/rootfs/*.sh spike/a/*.sh
 
   build:
     name: build rootfs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# build output
+/out/
+guest/rootfs/out/
+spike/a/dl/
+*.exe
+
+# go
+/hawser
+go.work
+go.work.sum

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ the [issue tracker](https://github.com/zcsizmadia/hawser/issues) is the live sta
 Windows containers, Kubernetes, or a management GUI. Because Hawser serves the standard
 Docker API, existing frontends (Portainer, lazydocker, VS Code) already work against it.
 
+## Repository layout
+
+Standard Go project layout — the Go toolchain, not a framework, decides this shape:
+
+```
+cmd/hawser/     the binary; one entry point, three run modes (CLI, service, tray)
+internal/       implementation packages, compiler-enforced private to this module
+  wsl/          every wsl.exe call, behind an interface so tests run anywhere
+  ...           provision, pipeproxy, engine, doctor, svc, tray as they land
+guest/          Linux side: rootfs build scripts, vsock agent
+installer/      winget/scoop/choco manifests, WiX MSI
+test/e2e/       cross-package suite; the only part needing real WSL2
+spike/          throwaway experiments, deleted once their issue closes
+```
+
+Two Go conventions worth stating, since they surprise people arriving from other ecosystems:
+**tests live beside the code they test** (`wsl.go` and `wsl_test.go` in the same folder — the
+`_test.go` suffix is how the toolchain finds them, and package-private tests need it), and
+there is no `src/` — the module root *is* the source root, and `internal/` is a compiler
+rule (nothing outside this module can import it), not a naming preference. `test/e2e/` exists
+only for suites that belong to no single package.
+
 ## License
 
 [Apache-2.0](LICENSE). Docker and the Docker logo are trademarks of Docker, Inc.

--- a/guest/rootfs/README.md
+++ b/guest/rootfs/README.md
@@ -1,0 +1,45 @@
+# Hawser rootfs
+
+The Linux side of Hawser: an Alpine base plus the engine, built into a tarball that
+`wsl --import` turns into the `hawser-engine` distro.
+
+## Provenance
+
+Engine binaries are **compiled from upstream source** (moby, containerd, runc, buildkit at
+pinned git tags) rather than repackaged from `download.docker.com`. Two reasons: the SBOM
+can point at a commit instead of someone else's zip, and redistributing Docker Inc.'s
+compiled bundles raises a trademark question that building from Apache-2.0 source doesn't.
+See PLAN §04 and the trademark risk row in §09.
+
+## Build
+
+Needs Linux + Docker — CI uses `ubuntu-latest`; locally a WSL2 Ubuntu distro works.
+
+```bash
+./build.sh [out-dir]        # default ./out — takes ~30 min, mostly compiling moby
+./smoke-test.sh out         # verify the artifact before trusting it
+```
+
+Outputs, all three of which become release assets:
+
+- `hawser-rootfs-<version>.tar.gz` — the distro image
+- `hawser-rootfs-<version>.tar.gz.sha256` — what `hawser install` verifies before importing
+- `hawser-rootfs-<version>.spdx.json` — SBOM, so a security team can diff what's inside
+
+The tarball is built deterministically (sorted entries, fixed mtimes and ownership,
+timestamp-free gzip), so the same pins reproduce the same checksum.
+
+## Versions
+
+Every pin lives in `versions.env` — nothing is ever fetched as "latest". The component
+combination there is the one the acceptance suite validates; bumping any single pin means
+re-running acceptance, because `hawser engine upgrade` refuses combinations outside the
+tested matrix (PLAN §04).
+
+## What's baked in
+
+- `/usr/local/bin/` — dockerd, containerd, containerd-shim-runc-v2, ctr, runc, buildkitd, buildctl
+- `/etc/docker/daemon.json` — log rotation on from the first run
+- `/etc/wsl.conf` — systemd off (Hawser's Windows service supervises dockerd instead),
+  metadata on automounts, Windows PATH not appended into the distro
+- `/etc/hawser/engine-version` — what `hawser version` reports

--- a/guest/rootfs/build-engine.sh
+++ b/guest/rootfs/build-engine.sh
@@ -37,4 +37,7 @@ clone https://github.com/moby/buildkit.git "$BUILDKIT_VERSION" buildkit
 
 strip /out/bin/* 2>/dev/null || true
 chmod 0755 /out/bin/*
+# Hand the artifacts back to the invoking user; we are root inside the container
+# but /out is a host directory (see the HOST_UID comment in build.sh).
+chown -R "${HOST_UID:-0}:${HOST_GID:-0}" /out
 ls -la /out/bin

--- a/guest/rootfs/build-engine.sh
+++ b/guest/rootfs/build-engine.sh
@@ -11,8 +11,19 @@ mkdir -p /out/bin /src
 export CGO_ENABLED=0
 export GOFLAGS=-trimpath
 
+# Clone at a pinned tag and record the commit it resolved to.
+#
+# These are annotated tags, so refs/tags/<tag> points at a tag object rather
+# than a commit and git prints "warning: refs/tags/X ... is not a commit!"
+# during a shallow clone. It is cosmetic — git peels the tag and checks out the
+# right tree — but a tag can be moved upstream, so we pin the belt and record
+# the resolved SHA as the suspenders: that SHA is what the SBOM reports.
 clone() { # repo tag dir
-    git -c advice.detachedHead=false clone --depth 1 --branch "$2" "$1" "/src/$3"
+    git -c advice.detachedHead=false clone --depth 1 --branch "$2" "$1" "/src/$3" 2>&1 |
+        grep -v 'is not a commit!' || true
+    sha="$(git -C "/src/$3" rev-parse HEAD)"
+    printf '%s %s %s\n' "$3" "$2" "$sha" >> /out/commits.txt
+    echo "    $3 $2 -> $sha"
 }
 
 echo "--- runc $RUNC_VERSION"
@@ -34,8 +45,13 @@ clone https://github.com/moby/moby.git "$MOBY_TAG" moby
 
 echo "--- buildkit $BUILDKIT_VERSION"
 clone https://github.com/moby/buildkit.git "$BUILDKIT_VERSION" buildkit
-(cd /src/buildkit && go build -o /out/bin/buildkitd ./cmd/buildkitd && \
-    go build -o /out/bin/buildctl ./cmd/buildctl)
+# Without these ldflags buildkit reports "v0.0.0+unknown" — same trap as moby's
+# VERSION, and `hawser version` is supposed to report the truth.
+bk_rev="$(git -C /src/buildkit rev-parse HEAD)"
+bk_ld="-X github.com/moby/buildkit/version.Version=${BUILDKIT_VERSION#v}"
+bk_ld="$bk_ld -X github.com/moby/buildkit/version.Revision=$bk_rev"
+(cd /src/buildkit && go build -ldflags "$bk_ld" -o /out/bin/buildkitd ./cmd/buildkitd && \
+    go build -ldflags "$bk_ld" -o /out/bin/buildctl ./cmd/buildctl)
 
 strip /out/bin/* 2>/dev/null || true
 chmod 0755 /out/bin/*

--- a/guest/rootfs/build-engine.sh
+++ b/guest/rootfs/build-engine.sh
@@ -27,7 +27,9 @@ clone https://github.com/containerd/containerd.git "$CONTAINERD_VERSION" contain
 
 echo "--- moby (dockerd) $MOBY_TAG"
 clone https://github.com/moby/moby.git "$MOBY_TAG" moby
-(cd /src/moby && ./hack/make.sh binary-daemon && \
+# VERSION is what `dockerd --version` reports; without it moby stamps "dev",
+# which the smoke test rejects and `hawser version` would misreport.
+(cd /src/moby && VERSION="$ENGINE_VERSION" ./hack/make.sh binary-daemon && \
     find bundles -name dockerd -type f -exec cp {} /out/bin/ \;)
 
 echo "--- buildkit $BUILDKIT_VERSION"

--- a/guest/rootfs/build-engine.sh
+++ b/guest/rootfs/build-engine.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Runs INSIDE a pinned golang:alpine container (invoked by build.sh).
+# Clones each engine component at its pinned tag and builds a static binary.
+# Result: /out/bin/{dockerd,containerd,containerd-shim-runc-v2,ctr,runc,buildkitd,buildctl}
+set -eu
+
+apk add --no-cache git make bash musl-dev gcc libseccomp-dev libseccomp-static \
+    btrfs-progs-dev linux-headers pkgconf
+
+mkdir -p /out/bin /src
+export CGO_ENABLED=0
+export GOFLAGS=-trimpath
+
+clone() { # repo tag dir
+    git -c advice.detachedHead=false clone --depth 1 --branch "$2" "$1" "/src/$3"
+}
+
+echo "--- runc $RUNC_VERSION"
+clone https://github.com/opencontainers/runc.git "$RUNC_VERSION" runc
+# runc needs cgo for libseccomp; static via the seccomp buildtag.
+(cd /src/runc && CGO_ENABLED=1 make static BUILDTAGS="seccomp" && cp runc /out/bin/)
+
+echo "--- containerd $CONTAINERD_VERSION"
+clone https://github.com/containerd/containerd.git "$CONTAINERD_VERSION" containerd
+(cd /src/containerd && make STATIC=1 binaries && \
+    cp bin/containerd bin/containerd-shim-runc-v2 bin/ctr /out/bin/)
+
+echo "--- moby (dockerd) $MOBY_TAG"
+clone https://github.com/moby/moby.git "$MOBY_TAG" moby
+(cd /src/moby && ./hack/make.sh binary-daemon && \
+    find bundles -name dockerd -type f -exec cp {} /out/bin/ \;)
+
+echo "--- buildkit $BUILDKIT_VERSION"
+clone https://github.com/moby/buildkit.git "$BUILDKIT_VERSION" buildkit
+(cd /src/buildkit && go build -o /out/bin/buildkitd ./cmd/buildkitd && \
+    go build -o /out/bin/buildctl ./cmd/buildctl)
+
+strip /out/bin/* 2>/dev/null || true
+chmod 0755 /out/bin/*
+ls -la /out/bin

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Build the Hawser rootfs: Alpine + engine binaries compiled from upstream source.
+#
+# Runs in CI (ubuntu-latest, Docker available) and on any Linux host with Docker —
+# including a WSL2 Ubuntu distro, which is how it gets tested locally.
+#
+#   ./build.sh [output-dir]     default: ./out
+#
+# Output: hawser-rootfs-<version>.tar.gz, its .sha256, and an SPDX SBOM.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+out="${1:-$here/out}"
+# shellcheck source=versions.env
+. "$here/versions.env"
+
+mkdir -p "$out"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "==> fetching Alpine minirootfs $ALPINE_ROOTFS_VERSION"
+base="alpine-minirootfs-${ALPINE_ROOTFS_VERSION}-x86_64.tar.gz"
+url="https://dl-cdn.alpinelinux.org/alpine/${ALPINE_BRANCH}/releases/x86_64/${base}"
+curl -fsSL -o "$work/$base" "$url"
+curl -fsSL -o "$work/$base.sha256" "$url.sha256"
+(cd "$work" && sha256sum -c "$base.sha256")
+
+echo "==> building engine binaries from source (this is the slow part)"
+# Each component is built in a pinned golang image from its upstream git tag —
+# no download.docker.com artifacts, so provenance is source -> binary end to end.
+docker run --rm \
+  -v "$work:/out" \
+  -e "MOBY_TAG=$MOBY_TAG" \
+  -e "CONTAINERD_VERSION=$CONTAINERD_VERSION" \
+  -e "RUNC_VERSION=$RUNC_VERSION" \
+  -e "BUILDKIT_VERSION=$BUILDKIT_VERSION" \
+  -v "$here/build-engine.sh:/build-engine.sh:ro" \
+  "golang:${GO_VERSION}-alpine" sh /build-engine.sh
+
+echo "==> assembling rootfs"
+root="$work/rootfs"
+mkdir -p "$root"
+tar -xzf "$work/$base" -C "$root"
+install -d "$root/usr/local/bin" "$root/etc/docker" "$root/etc/hawser"
+install -m 0755 "$work/bin/"* "$root/usr/local/bin/"
+
+# Engine defaults: log rotation on from the first run (PLAN §05 v0.1).
+cat > "$root/etc/docker/daemon.json" <<'JSON'
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-files": "3" }
+}
+JSON
+
+# WSL-side distro config. systemd is off: hawser supervises dockerd itself
+# from the Windows service, so an init system inside the distro buys nothing.
+cat > "$root/etc/wsl.conf" <<'CONF'
+[boot]
+systemd=false
+
+[automount]
+enabled=true
+options="metadata"
+
+[interop]
+enabled=true
+appendWindowsPath=false
+CONF
+
+printf '%s\n' "$ENGINE_VERSION" > "$root/etc/hawser/engine-version"
+
+tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
+echo "==> writing $tarball"
+# Deterministic tar: sorted, fixed mtimes/ownership, gzip without a timestamp,
+# so identical inputs produce an identical checksum.
+tar --sort=name --owner=0 --group=0 --numeric-owner \
+    --mtime='UTC 2020-01-01' -C "$root" -cf - . | gzip -n > "$tarball"
+(cd "$out" && sha256sum "$(basename "$tarball")" > "$(basename "$tarball").sha256")
+
+echo "==> SBOM"
+"$here/sbom.sh" "$here/versions.env" "$out/hawser-rootfs-${ENGINE_VERSION}.spdx.json"
+
+ls -la "$out"
+echo "OK"

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -34,6 +34,7 @@ echo "==> building engine binaries from source (this is the slow part)"
 docker run --rm \
   -v "$work:/out" \
   -e "MOBY_TAG=$MOBY_TAG" \
+  -e "ENGINE_VERSION=$ENGINE_VERSION" \
   -e "CONTAINERD_VERSION=$CONTAINERD_VERSION" \
   -e "RUNC_VERSION=$RUNC_VERSION" \
   -e "BUILDKIT_VERSION=$BUILDKIT_VERSION" \

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -74,6 +74,9 @@ appendWindowsPath=false
 CONF
 
 printf '%s\n' "$ENGINE_VERSION" > "$root/etc/hawser/engine-version"
+# Exact upstream commit each binary was built from — the provenance record
+# `hawser version` and a security review both read.
+install -m 0644 "$work/commits.txt" "$root/etc/hawser/commits"
 
 tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
 echo "==> writing $tarball"

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -28,12 +28,17 @@ curl -fsSL -o "$work/$base.sha256" "$url.sha256"
 echo "==> building engine binaries from source (this is the slow part)"
 # Each component is built in a pinned golang image from its upstream git tag —
 # no download.docker.com artifacts, so provenance is source -> binary end to end.
+# HOST_UID/GID: the build runs as root in the container but writes into a host
+# directory, so it hands ownership back before exiting — otherwise cleanup and
+# the tar step hit permission errors on the CI runner.
 docker run --rm \
   -v "$work:/out" \
   -e "MOBY_TAG=$MOBY_TAG" \
   -e "CONTAINERD_VERSION=$CONTAINERD_VERSION" \
   -e "RUNC_VERSION=$RUNC_VERSION" \
   -e "BUILDKIT_VERSION=$BUILDKIT_VERSION" \
+  -e "HOST_UID=$(id -u)" \
+  -e "HOST_GID=$(id -g)" \
   -v "$here/build-engine.sh:/build-engine.sh:ro" \
   "golang:${GO_VERSION}-alpine" sh /build-engine.sh
 

--- a/guest/rootfs/sbom.sh
+++ b/guest/rootfs/sbom.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Emit a minimal SPDX 2.3 SBOM for the rootfs from the pinned versions.
+# Deliberately dependency-free: a security team can diff this against
+# versions.env by eye. Richer scanning (syft) can layer on later.
+#   ./sbom.sh versions.env out.spdx.json
+set -euo pipefail
+
+versions="${1:?usage: sbom.sh <versions.env> <output.spdx.json>}"
+output="${2:?usage: sbom.sh <versions.env> <output.spdx.json>}"
+# shellcheck disable=SC1090
+. "$versions"
+
+sep=""
+pkg() { # name version download-location license
+  printf '%s    {\n' "$sep"
+  cat <<JSON
+      "SPDXID": "SPDXRef-Package-$1",
+      "name": "$1",
+      "versionInfo": "$2",
+      "downloadLocation": "$3",
+      "filesAnalyzed": false,
+      "licenseDeclared": "$4",
+      "licenseConcluded": "$4",
+      "supplier": "NOASSERTION"
+JSON
+  printf '    }'
+  sep=",
+"
+}
+
+{
+  cat <<JSON
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "hawser-rootfs-${ENGINE_VERSION}",
+  "documentNamespace": "https://github.com/zcsizmadia/hawser/spdx/rootfs-${ENGINE_VERSION}",
+  "creationInfo": {
+    "created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "creators": ["Tool: hawser-rootfs-build", "Organization: Hawser"]
+  },
+  "packages": [
+JSON
+  pkg "alpine-minirootfs" "$ALPINE_ROOTFS_VERSION" \
+      "https://dl-cdn.alpinelinux.org/alpine/$ALPINE_BRANCH/releases/x86_64/" "MIT AND GPL-2.0-only"
+  pkg "moby" "$MOBY_TAG" "https://github.com/moby/moby.git" "Apache-2.0"
+  pkg "containerd" "$CONTAINERD_VERSION" "https://github.com/containerd/containerd.git" "Apache-2.0"
+  pkg "runc" "$RUNC_VERSION" "https://github.com/opencontainers/runc.git" "Apache-2.0"
+  pkg "buildkit" "$BUILDKIT_VERSION" "https://github.com/moby/buildkit.git" "Apache-2.0"
+  pkg "go" "$GO_VERSION" "https://go.dev/dl/" "BSD-3-Clause"
+  cat <<'JSON'
+
+  ]
+}
+JSON
+} > "$output"
+
+echo "SBOM: $output"

--- a/guest/rootfs/smoke-test.sh
+++ b/guest/rootfs/smoke-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Verify a built rootfs before it can become a release asset.
+# Runs the engine binaries out of the tarball on the Linux CI host — this is
+# not the full acceptance suite (that needs WSL2), just proof the artifact
+# isn't broken: right shape, right versions, binaries actually execute.
+#   ./smoke-test.sh <out-dir>
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+out="${1:?usage: smoke-test.sh <out-dir>}"
+# shellcheck source=versions.env
+. "$here/versions.env"
+
+tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
+sbom="$out/hawser-rootfs-${ENGINE_VERSION}.spdx.json"
+
+echo "==> artifacts present"
+test -f "$tarball" || { echo "missing $tarball"; exit 1; }
+test -f "$tarball.sha256" || { echo "missing checksum"; exit 1; }
+test -f "$sbom" || { echo "missing SBOM"; exit 1; }
+(cd "$out" && sha256sum -c "$(basename "$tarball").sha256")
+python3 -c "import json,sys; json.load(open('$sbom'))" && echo "SBOM parses as JSON"
+
+echo "==> unpack"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+tar -xzf "$tarball" -C "$work"
+
+echo "==> expected files"
+for f in usr/local/bin/dockerd usr/local/bin/containerd usr/local/bin/runc \
+         usr/local/bin/buildkitd etc/docker/daemon.json etc/wsl.conf \
+         etc/hawser/engine-version; do
+    test -e "$work/$f" || { echo "missing $f"; exit 1; }
+    echo "  ok $f"
+done
+
+echo "==> daemon.json is valid JSON with log rotation"
+python3 - "$work/etc/docker/daemon.json" <<'PY'
+import json, sys
+cfg = json.load(open(sys.argv[1]))
+assert cfg["log-opts"]["max-size"], "log rotation not configured"
+print("  ok", cfg)
+PY
+
+echo "==> binaries execute and report the pinned versions"
+"$work/usr/local/bin/dockerd" --version
+"$work/usr/local/bin/dockerd" --version | grep -q "$ENGINE_VERSION" \
+    || { echo "dockerd version does not match $ENGINE_VERSION"; exit 1; }
+"$work/usr/local/bin/containerd" --version
+"$work/usr/local/bin/runc" --version
+"$work/usr/local/bin/buildkitd" --version
+
+echo "==> statically linked (no interpreter needed inside the minimal rootfs)"
+for b in dockerd containerd runc buildkitd; do
+    if file "$work/usr/local/bin/$b" | grep -q "dynamically linked"; then
+        echo "  WARN $b is dynamically linked"
+    else
+        echo "  ok $b static"
+    fi
+done
+
+echo "smoke test PASSED"

--- a/guest/rootfs/smoke-test.sh
+++ b/guest/rootfs/smoke-test.sh
@@ -29,7 +29,7 @@ tar -xzf "$tarball" -C "$work"
 echo "==> expected files"
 for f in usr/local/bin/dockerd usr/local/bin/containerd usr/local/bin/runc \
          usr/local/bin/buildkitd etc/docker/daemon.json etc/wsl.conf \
-         etc/hawser/engine-version; do
+         etc/hawser/engine-version etc/hawser/commits; do
     test -e "$work/$f" || { echo "missing $f"; exit 1; }
     echo "  ok $f"
 done
@@ -47,8 +47,23 @@ echo "==> binaries execute and report the pinned versions"
 "$work/usr/local/bin/dockerd" --version | grep -q "$ENGINE_VERSION" \
     || { echo "dockerd version does not match $ENGINE_VERSION"; exit 1; }
 "$work/usr/local/bin/containerd" --version
+"$work/usr/local/bin/containerd" --version | grep -q "${CONTAINERD_VERSION#v}" \
+    || { echo "containerd version does not match $CONTAINERD_VERSION"; exit 1; }
 "$work/usr/local/bin/runc" --version
+"$work/usr/local/bin/runc" --version | grep -q "${RUNC_VERSION#v}" \
+    || { echo "runc version does not match $RUNC_VERSION"; exit 1; }
+# Catches the "v0.0.0+unknown" trap: buildkit only reports a real version when
+# built with the ldflags in build-engine.sh.
 "$work/usr/local/bin/buildkitd" --version
+"$work/usr/local/bin/buildkitd" --version | grep -q "${BUILDKIT_VERSION#v}" \
+    || { echo "buildkitd version does not match $BUILDKIT_VERSION"; exit 1; }
+
+echo "==> provenance: one pinned commit per component"
+cat "$work/etc/hawser/commits"
+for c in moby containerd runc buildkit; do
+    grep -q "^$c " "$work/etc/hawser/commits" \
+        || { echo "no commit recorded for $c"; exit 1; }
+done
 
 echo "==> statically linked (no interpreter needed inside the minimal rootfs)"
 for b in dockerd containerd runc buildkitd; do

--- a/guest/rootfs/versions.env
+++ b/guest/rootfs/versions.env
@@ -1,0 +1,21 @@
+# Pinned inputs for the Hawser rootfs. Nothing here is ever "latest" —
+# every bump is a reviewed commit, and these values land in the release manifest.
+
+ALPINE_BRANCH=v3.24
+ALPINE_ROOTFS_VERSION=3.24.1
+ALPINE_ROOTFS_SHA256=auto   # verified against Alpine's published .sha256 at build time
+
+# Engine components, built from source (git tags in their upstream repos).
+# ENGINE_VERSION is the user-facing number; MOBY_TAG is moby's own tag spelling.
+ENGINE_VERSION=29.7.2
+MOBY_TAG=docker-v29.7.2
+CONTAINERD_VERSION=v2.1.4
+RUNC_VERSION=v1.3.0
+BUILDKIT_VERSION=v0.27.0
+
+# The component combination above is what the acceptance suite validates.
+# Newer tags exist upstream; bumping one means re-running acceptance, because
+# "engine upgrade refuses combinations outside the tested matrix" (PLAN §04).
+
+# Toolchain used to build them; bumping this changes output, so it is pinned too.
+GO_VERSION=1.25.1

--- a/guest/rootfs/versions.env
+++ b/guest/rootfs/versions.env
@@ -18,4 +18,5 @@ BUILDKIT_VERSION=v0.27.0
 # "engine upgrade refuses combinations outside the tested matrix" (PLAN §04).
 
 # Toolchain used to build them; bumping this changes output, so it is pinned too.
-GO_VERSION=1.25.1
+# Floor is set by moby's go.mod (docker-v29.7.2 requires >= 1.26.3).
+GO_VERSION=1.26.7

--- a/scripts/install-tools.ps1
+++ b/scripts/install-tools.ps1
@@ -1,0 +1,38 @@
+# Install the local dev tools CI depends on, without needing admin or Docker.
+# Everything lands in %LOCALAPPDATA%\hawser-tools, which scripts/lint.ps1 checks.
+#
+#   pwsh -File scripts/install-tools.ps1
+$ErrorActionPreference = 'Stop'
+
+$tools = Join-Path $env:LOCALAPPDATA 'hawser-tools'
+New-Item -ItemType Directory -Force $tools | Out-Null
+
+# --- shellcheck (matches the CI job) ---------------------------------------
+if (Get-Command shellcheck -ErrorAction SilentlyContinue) {
+    Write-Host "shellcheck: already on PATH" -ForegroundColor Green
+} elseif (Test-Path (Join-Path $tools 'shellcheck.exe')) {
+    Write-Host "shellcheck: already in $tools" -ForegroundColor Green
+} else {
+    Write-Host "shellcheck: downloading..."
+    $zip = Join-Path $env:TEMP 'shellcheck.zip'
+    $ext = Join-Path $env:TEMP 'shellcheck-extract'
+    Invoke-WebRequest 'https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.zip' -OutFile $zip
+    Expand-Archive $zip -DestinationPath $ext -Force
+    $exe = Get-ChildItem -Recurse $ext -Filter 'shellcheck*.exe' | Select-Object -First 1
+    Copy-Item $exe.FullName (Join-Path $tools 'shellcheck.exe') -Force
+    Remove-Item $zip, $ext -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "shellcheck: installed to $tools" -ForegroundColor Green
+}
+
+# --- git hooks --------------------------------------------------------------
+git config core.hooksPath .githooks
+Write-Host "git hooks: core.hooksPath -> .githooks" -ForegroundColor Green
+
+# --- Go (informational; the installer needs a normal winget run) -----------
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
+    Write-Host "go: not installed - run 'winget install GoLang.Go', then reopen your terminal" -ForegroundColor Yellow
+} else {
+    Write-Host "go: $(go version)" -ForegroundColor Green
+}
+
+Write-Host "`nDone. Run scripts/lint.ps1 before committing." -ForegroundColor Cyan

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -1,0 +1,74 @@
+# Run the same checks CI runs, before committing. No arguments: lints everything.
+#
+# shellcheck is found in whichever of these exists first — native install, the
+# user's WSL distro, or the official container image — so nobody has to install
+# anything to get the same answer CI gives.
+[CmdletBinding()]
+param([switch]$SkipGo)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path $PSScriptRoot -Parent
+Push-Location $repo
+try {
+    $failed = @()
+
+    # --- shellcheck -------------------------------------------------------
+    # -x follows `source=` directives; -P SCRIPTDIR resolves them relative to
+    # each script's own directory (versions.env sits next to build.sh).
+    $shArgs = @('-x', '-P', 'SCRIPTDIR')
+    $files  = Get-ChildItem -Recurse -Filter *.sh -File |
+              ForEach-Object { [IO.Path]::GetRelativePath($repo, $_.FullName).Replace('\', '/') }
+
+    if (-not $files) {
+        Write-Host "shellcheck: no .sh files" -ForegroundColor DarkGray
+    } else {
+        $native = Get-Command shellcheck -ErrorAction SilentlyContinue
+        if (-not $native) {
+            # scripts/install-tools.ps1 puts it here when it isn't on PATH.
+            $local = Join-Path $env:LOCALAPPDATA 'hawser-tools\shellcheck.exe'
+            if (Test-Path $local) { $native = Get-Command $local }
+        }
+        $wslHas = $false
+        if (-not $native) {
+            wsl -e sh -c 'command -v shellcheck' *> $null
+            $wslHas = ($LASTEXITCODE -eq 0)
+        }
+
+        Write-Host "== shellcheck ($($files.Count) files)" -ForegroundColor Cyan
+        if ($native) {
+            & $native.Source @shArgs @files
+        } elseif ($wslHas) {
+            wsl -e shellcheck @shArgs @files
+        } elseif (Get-Command docker -ErrorAction SilentlyContinue) {
+            Write-Host "  (via koalaman/shellcheck container)" -ForegroundColor DarkGray
+            docker run --rm -v "${repo}:/mnt" -w /mnt koalaman/shellcheck:stable @shArgs @files
+        } else {
+            Write-Warning "no shellcheck available (install it, add it to WSL, or start Docker) - SKIPPED"
+            $LASTEXITCODE = 0
+        }
+        if ($LASTEXITCODE -ne 0) { $failed += 'shellcheck' } else { Write-Host "  ok" -ForegroundColor Green }
+    }
+
+    # --- go ---------------------------------------------------------------
+    if (-not $SkipGo) {
+        if (Get-Command go -ErrorAction SilentlyContinue) {
+            Write-Host "== gofmt / vet / test" -ForegroundColor Cyan
+            $bad = gofmt -l .
+            if ($bad) { Write-Host "gofmt needed:"; $bad; $failed += 'gofmt' }
+            go vet ./...   ; if ($LASTEXITCODE -ne 0) { $failed += 'go vet' }
+            go build ./... ; if ($LASTEXITCODE -ne 0) { $failed += 'go build' }
+            go test ./...  ; if ($LASTEXITCODE -ne 0) { $failed += 'go test' }
+            if ($failed.Count -eq 0) { Write-Host "  ok" -ForegroundColor Green }
+        } else {
+            Write-Warning "go not installed - Go checks SKIPPED (winget install GoLang.Go)"
+        }
+    }
+
+    if ($failed.Count) {
+        Write-Host "`nFAILED: $($failed -join ', ')" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "`nAll local checks passed." -ForegroundColor Green
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
Closes #5. The artifact every install depends on.

**Provenance decision made real:** engine binaries are compiled from upstream git tags (moby, containerd, runc, buildkit) in a pinned `golang:alpine` image — not repackaged from `download.docker.com`. That was the draft-6 PLAN change; this is the implementation. SBOM points at commits, and the trademark question about redistributing Docker Inc.''s compiled bundles goes away.

- `versions.env` — every input pinned. Note `MOBY_TAG=docker-v29.7.2`: moby tags releases with a `docker-` prefix, so `ENGINE_VERSION` (user-facing) is split from the tag spelling. All four tags verified to exist upstream before pinning.
- `build.sh` — checksum-verified Alpine base, engine build, deterministic tar (sorted, fixed mtimes/ownership, `gzip -n`) so identical pins reproduce an identical checksum
- `sbom.sh` — dependency-free SPDX 2.3; tested locally, emits valid JSON with real license IDs
- `smoke-test.sh` — the artifact gate: checksum verify, expected layout, `daemon.json` parses and has rotation, binaries execute and report the pinned version, static-linkage check
- `rootfs.yml` — shellcheck + build + smoke test; attaches tarball/checksum/SBOM on release publish. Path-filtered because the from-source build takes ~30 min.
- README also answers the layout question (why `cmd/` and `internal/` at root, why no `src/`, why tests sit beside code)

**Note on the first CI run:** this is the first real exercise of the from-source build. If a component''s build recipe needs adjusting, I''ll fix it on this branch before merging — that''s exactly what the run is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)