### PR TITLE
Fix daemon.json log opt: max-files -> max-file

### DIFF
--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -74,7 +74,7 @@ install -m 0755 "$engine/bin/"* "$root/usr/local/bin/"
 cat > "$root/etc/docker/daemon.json" <<'JSON'
 {
   "log-driver": "json-file",
-  "log-opts": { "max-size": "10m", "max-files": "3" }
+  "log-opts": { "max-size": "10m", "max-file": "3" }
 }
 JSON
 

--- a/guest/rootfs/smoke-test.sh
+++ b/guest/rootfs/smoke-test.sh
@@ -34,13 +34,18 @@ for f in usr/local/bin/dockerd usr/local/bin/containerd usr/local/bin/runc \
     echo "  ok $f"
 done
 
-echo "==> daemon.json is valid JSON with log rotation"
+echo "==> daemon.json is accepted by the engine, not merely valid JSON"
+# `dockerd --validate` parses the config the way the real daemon does and exits.
+# The earlier version of this check only asserted the JSON shape, which is why a
+# bad log opt ("max-files" instead of "max-file") passed CI and was caught by
+# hand in Spike A instead — dockerd refused to start with it. Never again.
 python3 - "$work/etc/docker/daemon.json" <<'PY'
 import json, sys
 cfg = json.load(open(sys.argv[1]))
 assert cfg["log-opts"]["max-size"], "log rotation not configured"
-print("  ok", cfg)
+print("  ok, parses:", cfg)
 PY
+"$work/usr/local/bin/dockerd" --validate --config-file "$work/etc/docker/daemon.json"
 
 echo "==> binaries execute and report the pinned versions"
 "$work/usr/local/bin/dockerd" --version

--- a/spike/a/03-setup.sh
+++ b/spike/a/03-setup.sh
@@ -11,7 +11,7 @@ mkdir -p /etc/docker /var/log
 cat > /etc/docker/daemon.json <<'EOF'
 {
   "log-driver": "json-file",
-  "log-opts": { "max-size": "10m", "max-files": "3" }
+  "log-opts": { "max-size": "10m", "max-file": "3" }
 }
 EOF
 

--- a/spike/a/relay/go.mod
+++ b/spike/a/relay/go.mod
@@ -3,3 +3,5 @@ module github.com/zcsizmadia/hawser/spike/a/relay
 go 1.22
 
 require github.com/Microsoft/go-winio v0.6.2
+
+require golang.org/x/sys v0.10.0 // indirect

--- a/spike/a/relay/go.sum
+++ b/spike/a/relay/go.sum
@@ -1,0 +1,4 @@
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
**Spike A found a shipped-artifact bug on its first run.** dockerd refused to start:

```
failed to start daemon: failed to set log opts: unknown log opt ''max-files'' for json-file log driver
```

The json-file driver''s key is `max-file` (singular). Every rootfs the pipeline has produced so far contains an engine that **cannot boot**. Fixed in `guest/rootfs/build.sh` and `spike/a/03-setup.sh`.

**Why CI missed it, and the actual fix:** the smoke test asserted the config was *valid JSON with a max-size key* — it never asked the engine whether it would accept it. It now runs `dockerd --validate --config-file` on the built config, which parses it exactly as the real daemon does (verified inside the spike distro: `configuration OK` after the fix, hard error before). That check would have failed the very first pipeline run.

This is the argument for spikes existing. Four green CI runs blessed a broken artifact; ten minutes of running it by hand caught it.

Also commits `spike/a/relay/go.sum`, which the relay build generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)