### PR TITLE
internal/pipeproxy: named pipe to engine transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/zcsizmadia/hawser
 
 go 1.23
+
+require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/pipeproxy/dial_wsl.go
+++ b/internal/pipeproxy/dial_wsl.go
@@ -1,0 +1,104 @@
+package pipeproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// WSLDialer reaches the engine socket by running socat inside the distro and
+// relaying its stdio — the v0.1 transport Spike A validated.
+//
+// One process per connection is the known cost: ~165 ms of wsl.exe startup,
+// measured in #2. It is accepted deliberately because it needs no guest agent,
+// no vsock plumbing, and no open port; v0.2 replaces it with a persistent agent
+// once the correctness this buys is locked in by tests.
+type WSLDialer struct {
+	// Distro is the WSL distribution name, e.g. "hawser-engine".
+	Distro string
+
+	// SocketPath is the engine socket inside the distro.
+	// Defaults to DefaultSocketPath.
+	SocketPath string
+
+	// Exe overrides the wsl.exe path. Empty uses PATH.
+	Exe string
+}
+
+// DefaultSocketPath is where dockerd listens inside the Hawser distro.
+const DefaultSocketPath = "/var/run/docker.sock"
+
+// Dial starts the relay process and returns its stdio as a connection.
+func (d *WSLDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	if d.Distro == "" {
+		return nil, fmt.Errorf("pipeproxy: WSLDialer.Distro is required")
+	}
+	socket := d.SocketPath
+	if socket == "" {
+		socket = DefaultSocketPath
+	}
+	exe := d.Exe
+	if exe == "" {
+		exe = "wsl.exe"
+	}
+
+	// --exec skips the shell, so nothing re-interprets the socket path and
+	// there is no shell process between us and socat.
+	cmd := exec.CommandContext(ctx, exe,
+		"-d", d.Distro,
+		"-u", "root",
+		"--exec", "socat", "STDIO", "UNIX-CONNECT:"+socket,
+	)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pipeproxy: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("pipeproxy: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		stdout.Close()
+		return nil, fmt.Errorf("pipeproxy: start %s: %w", exe, err)
+	}
+
+	return &procConn{cmd: cmd, in: stdin, out: stdout}, nil
+}
+
+// procConn presents a child process's stdio as a connection. Closing stdin is a
+// genuine half-close — socat sees EOF and shuts down its write side to the
+// engine socket, which is what makes request-body-then-read work.
+type procConn struct {
+	cmd  *exec.Cmd
+	in   io.WriteCloser
+	out  io.ReadCloser
+	done bool
+}
+
+func (p *procConn) Read(b []byte) (int, error)  { return p.out.Read(b) }
+func (p *procConn) Write(b []byte) (int, error) { return p.in.Write(b) }
+
+// CloseWrite propagates end-of-request without ending the response.
+func (p *procConn) CloseWrite() error { return p.in.Close() }
+
+// Close tears down the process and reaps it, so a busy client cannot leave a
+// trail of zombie wsl.exe processes behind.
+func (p *procConn) Close() error {
+	if p.done {
+		return nil
+	}
+	p.done = true
+
+	p.in.Close()
+	p.out.Close()
+	if p.cmd.Process != nil {
+		p.cmd.Process.Kill()
+	}
+	p.cmd.Wait()
+	return nil
+}

--- a/internal/pipeproxy/listen_windows.go
+++ b/internal/pipeproxy/listen_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package pipeproxy
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// DefaultPipeName is what stock docker.exe connects to when DOCKER_HOST is
+// unset. Hawser claims it only when Docker Desktop has not; the installer
+// falls back to FallbackPipeName so the two coexist (PLAN §02).
+const DefaultPipeName = `\\.\pipe\docker_engine`
+
+// FallbackPipeName is Hawser's own pipe, used when the default is taken.
+const FallbackPipeName = `\\.\pipe\hawser_engine`
+
+// DefaultSDDL restricts the pipe to SYSTEM, local administrators, and
+// interactive users.
+//
+// Pipe access is equivalent to root inside the engine VM, which in turn can
+// read and write anything the automounted drives expose — the same trust
+// boundary Docker Desktop has, and the reason this is not left at the default
+// descriptor. A service running as SYSTEM would otherwise own the pipe and shut
+// the logged-in user out.
+//
+// TODO(#8): once `hawser install` creates the local "Hawser Users" group, its
+// SID replaces IU here, matching Docker's docker-users pattern so non-admin
+// developer accounts can be granted access deliberately rather than by virtue
+// of being interactive.
+const DefaultSDDL = "D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;IU)"
+
+// Listen creates the named pipe. An empty sddl applies DefaultSDDL; pass a
+// custom descriptor only with a reason, since this is the security boundary.
+func Listen(pipeName, sddl string) (net.Listener, error) {
+	if pipeName == "" {
+		return nil, fmt.Errorf("pipeproxy: empty pipe name")
+	}
+	if sddl == "" {
+		sddl = DefaultSDDL
+	}
+
+	l, err := winio.ListenPipe(pipeName, &winio.PipeConfig{
+		SecurityDescriptor: sddl,
+		// The engine API carries large payloads (image push/pull, build
+		// contexts); message mode would frame them wrongly. Byte mode is what
+		// dockerd's own Windows listener uses.
+		MessageMode: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pipeproxy: listen %s: %w", pipeName, err)
+	}
+	return l, nil
+}

--- a/internal/pipeproxy/listen_windows_test.go
+++ b/internal/pipeproxy/listen_windows_test.go
@@ -1,0 +1,135 @@
+//go:build windows
+
+package pipeproxy_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+)
+
+// testPipeName keeps concurrent runs (and a developer's real Hawser install)
+// from colliding.
+func testPipeName(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf(`\\.\pipe\hawser-test-%d-%s`, os.Getpid(), t.Name())
+}
+
+// TestListenServesOverRealPipe exercises the actual named pipe rather than a
+// TCP stand-in: this is the transport stock docker.exe uses, so the SDDL, byte
+// mode, and go-winio half-close behavior all get covered here.
+func TestListenServesOverRealPipe(t *testing.T) {
+	engine := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+
+	name := testPipeName(t)
+	l, err := pipeproxy.Listen(name, "")
+	if err != nil {
+		t.Fatalf("Listen(%s): %v", name, err)
+	}
+	defer l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := &pipeproxy.Server{Dialer: engine.dialer()}
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx, l) }()
+
+	conn, err := winio.DialPipe(name, nil)
+	if err != nil {
+		t.Fatalf("DialPipe: %v", err)
+	}
+	defer conn.Close()
+
+	want := "GET /_ping HTTP/1.1\r\n\r\n"
+	if _, err := io.WriteString(conn, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(want))
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("deadline: %v", err)
+	}
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != want {
+		t.Errorf("got %q, want %q", buf, want)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Serve: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("Serve did not return")
+	}
+}
+
+// TestListenBinaryOverRealPipe guards the byte-mode choice: in message mode a
+// large payload would be framed and truncated, which is how image pulls break.
+func TestListenBinaryOverRealPipe(t *testing.T) {
+	engine := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+
+	name := testPipeName(t)
+	l, err := pipeproxy.Listen(name, "")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go (&pipeproxy.Server{Dialer: engine.dialer()}).Serve(ctx, l)
+
+	conn, err := winio.DialPipe(name, nil)
+	if err != nil {
+		t.Fatalf("DialPipe: %v", err)
+	}
+	defer conn.Close()
+
+	payload := make([]byte, 128*1024)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	go func() {
+		conn.Write(payload)
+		if hc, ok := conn.(interface{ CloseWrite() error }); ok {
+			hc.CloseWrite()
+		}
+	}()
+
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("deadline: %v", err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read %d bytes: %v", len(payload), err)
+	}
+	for i := range payload {
+		if got[i] != payload[i] {
+			t.Fatalf("byte %d differs: got %#x want %#x", i, got[i], payload[i])
+		}
+	}
+}
+
+func TestListenRejectsEmptyName(t *testing.T) {
+	if _, err := pipeproxy.Listen("", ""); err == nil {
+		t.Error("Listen with empty name succeeded, want error")
+	}
+}
+
+func TestListenRejectsBadSDDL(t *testing.T) {
+	// A malformed descriptor must fail loudly at startup, not silently widen
+	// access — this is the pipe's security boundary.
+	if _, err := pipeproxy.Listen(testPipeName(t), "not-a-descriptor"); err == nil {
+		t.Error("Listen with invalid SDDL succeeded, want error")
+	}
+}

--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -1,0 +1,212 @@
+// Package pipeproxy bridges the Windows named pipe that stock docker.exe
+// expects to the engine's Unix socket inside the WSL2 distro.
+//
+// This is the load-bearing component the project is named for. Spike A (#2)
+// proved the design end to end and measured it: the per-connection relay
+// process starts in ~6 ms, while the surrounding wsl.exe startup costs ~165 ms
+// per connection — the cost the v0.2 vsock agent removes. Correctness matters
+// more than either number, because every Docker client behavior rides on it:
+// hijacked streams (exec -it, attach), incremental streaming (logs -f), and
+// half-closes (build, save) all break in different, confusing ways if the relay
+// is sloppy.
+//
+// The transport deliberately knows nothing about HTTP. Byte-for-byte fidelity
+// is what makes hijacked connections work at all; request rewriting (bind path
+// translation) is layered on top rather than baked in here.
+package pipeproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+)
+
+// Dialer opens one connection to the engine socket. Production dials through
+// wsl.exe; tests substitute a local socket, which is why the transport can be
+// verified on any machine without WSL2.
+type Dialer interface {
+	Dial(ctx context.Context) (io.ReadWriteCloser, error)
+}
+
+// DialerFunc adapts a function to Dialer.
+type DialerFunc func(ctx context.Context) (io.ReadWriteCloser, error)
+
+// Dial implements Dialer.
+func (f DialerFunc) Dial(ctx context.Context) (io.ReadWriteCloser, error) { return f(ctx) }
+
+// halfCloser is implemented by connections that can signal "no more writes"
+// without tearing the whole connection down. Propagating this is what lets a
+// client send a request body, half-close, and still read the response — the
+// docker build and docker save pattern.
+type halfCloser interface {
+	CloseWrite() error
+}
+
+// Server accepts client connections and relays each to the engine.
+type Server struct {
+	// Dialer opens the engine side of each connection. Required.
+	Dialer Dialer
+
+	// Logger receives connection lifecycle events. Defaults to slog.Default().
+	Logger *slog.Logger
+
+	// OnAccept, if set, wraps each accepted connection before relaying. The
+	// HTTP-rewriting layer hooks in here, so the transport stays oblivious.
+	OnAccept func(client net.Conn) net.Conn
+
+	wg sync.WaitGroup
+
+	mu     sync.Mutex
+	active map[io.Closer]struct{}
+}
+
+// track registers a connection so shutdown can close it. Without this, a
+// client holding a streaming connection open (docker logs -f, docker events)
+// would block service shutdown indefinitely: the relay only returns when one
+// side goes away, and neither side has a reason to.
+func (s *Server) track(c io.Closer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active == nil {
+		s.active = make(map[io.Closer]struct{})
+	}
+	s.active[c] = struct{}{}
+}
+
+func (s *Server) untrack(c io.Closer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.active, c)
+}
+
+// closeActive tears down every live connection, unblocking their relays.
+func (s *Server) closeActive() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c := range s.active {
+		c.Close()
+	}
+}
+
+func (s *Server) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}
+
+// Serve accepts connections until ctx is cancelled or the listener fails, then
+// waits for in-flight connections to finish. Closing the listener is the
+// caller's job: Serve returns as soon as Accept fails, which is what a closed
+// listener produces.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	if s.Dialer == nil {
+		return errors.New("pipeproxy: Dialer is required")
+	}
+
+	// Unblock Accept on cancellation — a named pipe Accept has no deadline —
+	// and drop live connections so a streaming client cannot pin shutdown.
+	go func() {
+		<-ctx.Done()
+		l.Close()
+		s.closeActive()
+	}()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			s.wg.Wait()
+			if ctx.Err() != nil {
+				return nil // shutdown, not failure
+			}
+			return fmt.Errorf("pipeproxy: accept: %w", err)
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handle(ctx, conn)
+		}()
+	}
+}
+
+func (s *Server) handle(ctx context.Context, client net.Conn) {
+	log := s.logger()
+	defer client.Close()
+
+	s.track(client)
+	defer s.untrack(client)
+
+	if s.OnAccept != nil {
+		client = s.OnAccept(client)
+	}
+
+	engine, err := s.Dialer.Dial(ctx)
+	if err != nil {
+		// The client is left to see a closed connection; there is no HTTP
+		// response to send, because the transport does not speak HTTP.
+		log.Error("dial engine", "error", err)
+		return
+	}
+	defer engine.Close()
+
+	s.track(engine)
+	defer s.untrack(engine)
+
+	if err := Relay(client, engine); err != nil {
+		log.Debug("relay ended", "error", err)
+	}
+}
+
+// Relay copies bytes in both directions until both are done.
+//
+// Each direction propagates its own end-of-stream as a half-close rather than a
+// full close, so a client that finished sending can still read the response.
+// Both directions must be allowed to drain: returning as soon as one finishes
+// would truncate the other, which is how naive relays break `docker build`.
+func Relay(client, engine io.ReadWriteCloser) error {
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := io.Copy(engine, client)
+		errs[0] = err
+		closeWrite(engine)
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := io.Copy(client, engine)
+		errs[1] = err
+		closeWrite(client)
+	}()
+	wg.Wait()
+
+	return errors.Join(filterClosed(errs[0]), filterClosed(errs[1]))
+}
+
+// closeWrite signals end-of-stream to the peer, preferring a half-close so the
+// other direction survives. Types without CloseWrite get nothing: a full Close
+// here would kill the still-active reverse direction.
+func closeWrite(c io.ReadWriteCloser) {
+	if hc, ok := c.(halfCloser); ok {
+		hc.CloseWrite()
+	}
+}
+
+// filterClosed drops the errors that mean "the other end went away", which is
+// the normal way a docker client ends a connection, not a fault worth logging.
+func filterClosed(err error) error {
+	if err == nil ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, io.ErrClosedPipe) {
+		return nil
+	}
+	return err
+}

--- a/internal/pipeproxy/relay_test.go
+++ b/internal/pipeproxy/relay_test.go
@@ -1,0 +1,375 @@
+package pipeproxy_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+)
+
+// echoServer stands in for dockerd: a local TCP listener whose connections
+// support CloseWrite, so half-close semantics are exercised for real rather
+// than mocked. net.Pipe would not do — it has no CloseWrite.
+type echoServer struct {
+	l      net.Listener
+	handle func(net.Conn)
+}
+
+func newServer(t *testing.T, handle func(net.Conn)) *echoServer {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &echoServer{l: l, handle: handle}
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				s.handle(c)
+			}()
+		}
+	}()
+	t.Cleanup(func() { l.Close() })
+	return s
+}
+
+func (s *echoServer) dialer() pipeproxy.Dialer {
+	return pipeproxy.DialerFunc(func(ctx context.Context) (io.ReadWriteCloser, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", s.l.Addr().String())
+	})
+}
+
+// startProxy runs a Server on a local listener and returns its address.
+func startProxy(t *testing.T, srv *pipeproxy.Server) (addr string, stop func()) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx, l) }()
+
+	return l.Addr().String(), func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Serve returned %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("Serve did not return after cancel")
+		}
+	}
+}
+
+func TestRelayEchoesBothDirections(t *testing.T) {
+	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer c.Close()
+
+	want := "GET /_ping HTTP/1.1\r\n\r\n"
+	if _, err := io.WriteString(c, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(want))
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != want {
+		t.Errorf("got %q, want %q", buf, want)
+	}
+}
+
+func TestRelayPropagatesHalfClose(t *testing.T) {
+	// The docker build / docker save shape: the client streams a body, signals
+	// end-of-request with a half-close, and only then expects a response. If
+	// the relay turns that half-close into a full close, or fails to propagate
+	// it, the server either never responds or the response is truncated.
+	srv := newServer(t, func(c net.Conn) {
+		body, err := io.ReadAll(c) // returns only when the half-close arrives
+		if err != nil {
+			return
+		}
+		fmt.Fprintf(c, "received %d bytes", len(body))
+	})
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer c.Close()
+
+	payload := make([]byte, 64*1024)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	if _, err := c.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := c.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+
+	resp, err := io.ReadAll(c)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	want := fmt.Sprintf("received %d bytes", len(payload))
+	if string(resp) != want {
+		t.Errorf("got %q, want %q", resp, want)
+	}
+}
+
+func TestRelayStreamsIncrementally(t *testing.T) {
+	// The docker logs -f shape: output must arrive as it is produced, not
+	// buffered until the connection closes.
+	srv := newServer(t, func(c net.Conn) {
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(c, "line-%d\n", i)
+			time.Sleep(20 * time.Millisecond)
+		}
+	})
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer c.Close()
+
+	buf := make([]byte, 7)
+	if err := c.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("deadline: %v", err)
+	}
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read first line: %v", err)
+	}
+	if string(buf) != "line-0\n" {
+		t.Errorf("first read = %q, want %q", buf, "line-0\n")
+	}
+}
+
+func TestRelayBinarySafe(t *testing.T) {
+	// docker save / image push carry arbitrary bytes; Spike A checked this
+	// against a real engine, and this keeps it true without one.
+	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer c.Close()
+
+	payload := make([]byte, 256*1024)
+	for i := range payload {
+		payload[i] = byte(i) // every byte value, including 0x00 and 0xFF
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Write(payload)
+		c.(*net.TCPConn).CloseWrite()
+	}()
+
+	got, err := io.ReadAll(c)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != len(payload) {
+		t.Fatalf("got %d bytes, want %d", len(got), len(payload))
+	}
+	for i := range payload {
+		if got[i] != payload[i] {
+			t.Fatalf("byte %d differs: got %#x want %#x", i, got[i], payload[i])
+		}
+	}
+}
+
+func TestRelayConcurrentConnections(t *testing.T) {
+	// Compose opens many connections at once; each must stay independent.
+	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	defer stop()
+
+	const n = 25
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c, err := net.Dial("tcp", addr)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer c.Close()
+
+			want := fmt.Sprintf("connection-%03d", i)
+			if _, err := io.WriteString(c, want); err != nil {
+				errCh <- err
+				return
+			}
+			buf := make([]byte, len(want))
+			if _, err := io.ReadFull(c, buf); err != nil {
+				errCh <- err
+				return
+			}
+			if string(buf) != want {
+				errCh <- fmt.Errorf("crossed streams: got %q want %q", buf, want)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+func TestServeShutsDownWithStreamingClient(t *testing.T) {
+	// The docker logs -f / docker events shape: a connection neither side
+	// wants to end. Cancelling the context must still stop Serve promptly,
+	// or stopping the Windows service would hang whenever someone left a
+	// follow running.
+	srv := newServer(t, func(c net.Conn) {
+		for {
+			if _, err := io.WriteString(c, "tick\n"); err != nil {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- (&pipeproxy.Server{Dialer: srv.dialer()}).Serve(ctx, l) }()
+
+	c, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	// Read one chunk so the relay is definitely established and streaming.
+	buf := make([]byte, 5)
+	c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Serve returned %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return while a client was streaming")
+	}
+}
+
+func TestServeRequiresDialer(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	if err := (&pipeproxy.Server{}).Serve(context.Background(), l); err == nil {
+		t.Error("Serve with no Dialer succeeded, want error")
+	}
+}
+
+func TestServeStopsOnContextCancel(t *testing.T) {
+	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+	_, stop := startProxy(t, &pipeproxy.Server{Dialer: srv.dialer()})
+	stop() // asserts Serve returns nil, not an accept error, on cancellation
+}
+
+func TestDialFailureClosesClient(t *testing.T) {
+	// If the engine is down, the client must see a closed connection rather
+	// than hang — docker reports "error during connect", which is honest.
+	failing := pipeproxy.DialerFunc(func(context.Context) (io.ReadWriteCloser, error) {
+		return nil, errors.New("engine unavailable")
+	})
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: failing})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer c.Close()
+
+	if err := c.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("deadline: %v", err)
+	}
+	if _, err := io.ReadAll(c); err != nil {
+		t.Fatalf("expected clean EOF, got %v", err)
+	}
+}
+
+func TestOnAcceptWraps(t *testing.T) {
+	// The hook the HTTP-rewriting layer will use.
+	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
+	var called bool
+	var mu sync.Mutex
+	proxy := &pipeproxy.Server{
+		Dialer: srv.dialer(),
+		OnAccept: func(c net.Conn) net.Conn {
+			mu.Lock()
+			called = true
+			mu.Unlock()
+			return c
+		},
+	}
+	addr, stop := startProxy(t, proxy)
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	io.WriteString(c, "x")
+	buf := make([]byte, 1)
+	io.ReadFull(c, buf)
+	c.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !called {
+		t.Error("OnAccept was not called")
+	}
+}


### PR DESCRIPTION
Toward #6 — the transport layer of the load-bearing component. HTTP-level bind-path rewriting (using the `winpath` package from #17) layers on top via `OnAccept` in a follow-up PR; keeping them separate because their tests are entirely different in character, and this half is what everything else depends on.

**Deliberately HTTP-oblivious.** Byte-for-byte fidelity is what makes hijacked connections (`exec -it`, `attach`) work at all, so nothing here parses a request.

- **`Relay`** — bidirectional copy with **half-close propagated in both directions**, so a client can send a body, half-close, then read the response. That''s the `docker build` / `docker save` shape, and the thing naive relays truncate.
- **`Server.Serve`** — concurrent connections, graceful drain, and shutdown that *closes* live connections instead of waiting on them.
- **`Listen`** (Windows) — go-winio pipe with an explicit SDDL: SYSTEM, administrators, interactive users. Explicit because a service running as SYSTEM would otherwise own the pipe and lock the logged-in user out. **Byte mode, not message mode** — message framing truncates large payloads, which is how image pulls break. `TODO(#8)` marks where the local `Hawser Users` group SID replaces `IU`.
- **`WSLDialer`** — one `wsl.exe`+socat per connection, the v0.1 design Spike A validated. Closing stdin is a genuine half-close, and `Close` reaps the child so a busy client can''t leave zombie `wsl.exe` processes behind.

**A real bug surfaced while writing the real-pipe test.** `Serve` waited for in-flight connections to finish — so any streaming client (`docker logs -f`, `docker events`) would have **pinned service shutdown forever**. The test hung for 5s and failed. `Serve` now tracks live connections and closes them on cancellation; that test is kept as `TestServeShutsDownWithStreamingClient` and now passes in 0.01s. Worth calling out because it would have shown up as "stopping the Hawser service hangs" long after the fact.

**14 tests, 70% coverage.** The `Dialer` seam verifies transport behavior with no WSL2 (half-close, streaming, 256 KB binary round-trip, 25 concurrent connections, dial failure), while the Windows tests drive a **real named pipe** through go-winio — the same transport stock `docker.exe` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)