### PR TITLE
Pipe proxy: bind-path rewriting (completes #6)

### DIFF
--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -54,9 +54,10 @@ type Server struct {
 	// Logger receives connection lifecycle events. Defaults to slog.Default().
 	Logger *slog.Logger
 
-	// OnAccept, if set, wraps each accepted connection before relaying. The
-	// HTTP-rewriting layer hooks in here, so the transport stays oblivious.
-	OnAccept func(client net.Conn) net.Conn
+	// Handler relays one accepted connection. Defaults to Relay, a byte-for-byte
+	// copy. RewriteBinds substitutes an HTTP-aware handler that translates
+	// Windows bind paths; the transport itself stays oblivious either way.
+	Handler func(client net.Conn, engine io.ReadWriteCloser) error
 
 	wg sync.WaitGroup
 
@@ -141,10 +142,6 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 	s.track(client)
 	defer s.untrack(client)
 
-	if s.OnAccept != nil {
-		client = s.OnAccept(client)
-	}
-
 	engine, err := s.Dialer.Dial(ctx)
 	if err != nil {
 		// The client is left to see a closed connection; there is no HTTP
@@ -157,12 +154,19 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 	s.track(engine)
 	defer s.untrack(engine)
 
-	if err := Relay(client, engine); err != nil {
-		log.Debug("relay ended", "error", err)
+	handler := s.Handler
+	if handler == nil {
+		// Relay accepts the more general io.ReadWriteCloser for its client, so
+		// it needs a thin adapter to fit the Handler signature.
+		handler = func(c net.Conn, e io.ReadWriteCloser) error { return Relay(c, e) }
+	}
+	if err := handler(client, engine); err != nil {
+		log.Debug("connection ended", "error", err)
 	}
 }
 
-// Relay copies bytes in both directions until both are done.
+// Relay copies bytes in both directions until both are done. It satisfies the
+// Server.Handler signature and is the default.
 //
 // Each direction propagates its own end-of-stream as a half-close rather than a
 // full close, so a client that finished sending can still read the response.

--- a/internal/pipeproxy/relay_test.go
+++ b/internal/pipeproxy/relay_test.go
@@ -341,18 +341,19 @@ func TestDialFailureClosesClient(t *testing.T) {
 	}
 }
 
-func TestOnAcceptWraps(t *testing.T) {
-	// The hook the HTTP-rewriting layer will use.
+func TestCustomHandlerReplacesRelay(t *testing.T) {
+	// The seam RewriteBinds plugs into: a handler fully replaces the default
+	// byte relay rather than wrapping the connection.
 	srv := newServer(t, func(c net.Conn) { io.Copy(c, c) })
 	var called bool
 	var mu sync.Mutex
 	proxy := &pipeproxy.Server{
 		Dialer: srv.dialer(),
-		OnAccept: func(c net.Conn) net.Conn {
+		Handler: func(c net.Conn, e io.ReadWriteCloser) error {
 			mu.Lock()
 			called = true
 			mu.Unlock()
-			return c
+			return pipeproxy.Relay(c, e)
 		},
 	}
 	addr, stop := startProxy(t, proxy)
@@ -370,6 +371,6 @@ func TestOnAcceptWraps(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	if !called {
-		t.Error("OnAccept was not called")
+		t.Error("custom Handler was not called")
 	}
 }

--- a/internal/pipeproxy/rewrite.go
+++ b/internal/pipeproxy/rewrite.go
@@ -1,0 +1,292 @@
+package pipeproxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/zcsizmadia/hawser/internal/winpath"
+)
+
+// RewriteBinds is a Server.Handler that translates Windows bind paths on their
+// way to the engine, then gets out of the way.
+//
+// Spike A (#2) established why this is necessary and where it must happen: the
+// daemon rejects "C:\src:/app" itself, and the CLI forwards the spec untouched,
+// so the proxy is the only place left. It must also be surgical — every other
+// byte has to pass through unaltered, because Docker hijacks connections for
+// exec, attach, and logs, and a hijacked stream is not HTTP at all.
+//
+// The handler therefore proxies HTTP only until the engine signals a hijack,
+// then reverts to a raw byte relay for the life of the connection.
+func RewriteBinds(client net.Conn, engine io.ReadWriteCloser) error {
+	clientR := bufio.NewReader(client)
+	engineR := bufio.NewReader(engine)
+
+	for {
+		req, err := http.ReadRequest(clientR)
+		if err != nil {
+			// EOF is the ordinary end of a keep-alive connection.
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("read request: %w", err)
+		}
+
+		if isContainerCreate(req) {
+			if err := rewriteCreateBody(req); err != nil {
+				// Refusing is better than forwarding a mount the user did not
+				// ask for; report it as the API would.
+				return writeError(client, http.StatusBadRequest, err)
+			}
+		}
+
+		if err := req.Write(engine); err != nil {
+			return fmt.Errorf("forward request: %w", err)
+		}
+
+		resp, err := http.ReadResponse(engineR, req)
+		if err != nil {
+			return fmt.Errorf("read response: %w", err)
+		}
+
+		if isHijack(resp) {
+			// From here the connection carries a raw multiplexed stream, so
+			// hand back the headers verbatim and stop parsing entirely.
+			if err := writeResponseHead(client, resp); err != nil {
+				resp.Body.Close()
+				return err
+			}
+			return relayBuffered(client, engine, clientR, engineR)
+		}
+
+		// resp.Write streams the body as it arrives, which is what keeps
+		// `docker logs -f` and pull progress incremental.
+		if err := resp.Write(client); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("forward response: %w", err)
+		}
+		resp.Body.Close()
+
+		if resp.Close || req.Close {
+			return nil
+		}
+	}
+}
+
+// containerCreatePath matches /containers/create with or without the version
+// prefix the CLI normally sends (/v1.55/containers/create).
+var containerCreatePath = regexp.MustCompile(`^(/v[0-9.]+)?/containers/create$`)
+
+func isContainerCreate(req *http.Request) bool {
+	return req.Method == http.MethodPost && containerCreatePath.MatchString(req.URL.Path)
+}
+
+// hijackContentTypes are the media types dockerd uses for raw and multiplexed
+// container streams. Docker does not always answer an upgrade with 101: when
+// the client does not request an upgrade, exec and attach return 200 and then
+// stream, so status code alone is not enough to detect a hijack.
+var hijackContentTypes = []string{
+	"application/vnd.docker.raw-stream",
+	"application/vnd.docker.multiplexed-stream",
+}
+
+func isHijack(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		return true
+	}
+	ct := resp.Header.Get("Content-Type")
+	for _, h := range hijackContentTypes {
+		if strings.HasPrefix(ct, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteCreateBody translates bind paths in a container-create request.
+//
+// The body is decoded into a generic map rather than a typed struct so that
+// fields this code does not know about survive untouched — the engine API grows
+// every release, and silently dropping a caller's option would be far worse
+// than not translating a path. json.Number likewise preserves numeric literals
+// exactly instead of round-tripping them through float64.
+func rewriteCreateBody(req *http.Request) error {
+	if req.Body == nil {
+		return nil
+	}
+	raw, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return fmt.Errorf("read create body: %w", err)
+	}
+	if len(raw) == 0 {
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		return nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var body map[string]any
+	if err := dec.Decode(&body); err != nil {
+		// Not JSON we understand: pass it through and let the engine judge it.
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		return nil
+	}
+
+	changed, err := translateHostConfig(body)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		return nil
+	}
+
+	out, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("re-encode create body: %w", err)
+	}
+	req.Body = io.NopCloser(bytes.NewReader(out))
+	req.ContentLength = int64(len(out))
+	// The rewrite changes the length, so a stale Content-Length header would
+	// desynchronize the stream. Drop any chunked framing for the same reason.
+	req.Header.Del("Content-Length")
+	req.TransferEncoding = nil
+	return nil
+}
+
+// translateHostConfig rewrites HostConfig.Binds and the source of any bind-type
+// entry in HostConfig.Mounts, reporting whether anything changed.
+func translateHostConfig(body map[string]any) (bool, error) {
+	hc, ok := body["HostConfig"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	var changed bool
+
+	if rawBinds, ok := hc["Binds"].([]any); ok {
+		binds := make([]string, 0, len(rawBinds))
+		for _, b := range rawBinds {
+			s, ok := b.(string)
+			if !ok {
+				return false, fmt.Errorf("HostConfig.Binds contains a non-string entry")
+			}
+			binds = append(binds, s)
+		}
+		translated, err := winpath.TranslateBinds(binds)
+		if err != nil {
+			return false, err
+		}
+		for i := range translated {
+			if translated[i] != binds[i] {
+				changed = true
+			}
+		}
+		if changed {
+			next := make([]any, len(translated))
+			for i, s := range translated {
+				next[i] = s
+			}
+			hc["Binds"] = next
+		}
+	}
+
+	// --mount syntax, and what compose emits for long-form volumes.
+	if mounts, ok := hc["Mounts"].([]any); ok {
+		for _, m := range mounts {
+			mount, ok := m.(map[string]any)
+			if !ok {
+				continue
+			}
+			// Only bind mounts name a host path; a volume's Source is a name.
+			if t, _ := mount["Type"].(string); t != "bind" {
+				continue
+			}
+			src, ok := mount["Source"].(string)
+			if !ok || src == "" {
+				continue
+			}
+			translated, err := winpath.ToWSL(src)
+			if err != nil {
+				return false, err
+			}
+			if translated != src {
+				mount["Source"] = translated
+				changed = true
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+// writeResponseHead emits a status line and headers without touching the body,
+// used when the connection is about to become a raw stream.
+func writeResponseHead(w io.Writer, resp *http.Response) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "HTTP/1.1 %d %s\r\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+	if err := resp.Header.Write(&b); err != nil {
+		return err
+	}
+	b.WriteString("\r\n")
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return fmt.Errorf("write hijack response head: %w", err)
+	}
+	return nil
+}
+
+// writeError reports a proxy-side refusal in the shape the Docker API uses, so
+// the CLI prints a real message instead of "error during connect".
+func writeError(w io.Writer, status int, cause error) error {
+	payload, err := json.Marshal(map[string]string{"message": cause.Error()})
+	if err != nil {
+		return err
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "HTTP/1.1 %d %s\r\n", status, http.StatusText(status))
+	b.WriteString("Content-Type: application/json\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(payload))
+	b.WriteString("Connection: close\r\n\r\n")
+	b.Write(payload)
+	if _, werr := io.WriteString(w, b.String()); werr != nil {
+		return werr
+	}
+	return nil
+}
+
+// relayBuffered switches to a raw byte relay, first flushing whatever the HTTP
+// readers already pulled off the wire. Skipping that would silently swallow the
+// first bytes of a hijacked stream — the kind of bug that looks like a hung
+// `docker exec` rather than a lost buffer.
+func relayBuffered(client net.Conn, engine io.ReadWriteCloser, clientR, engineR *bufio.Reader) error {
+	if n := engineR.Buffered(); n > 0 {
+		buf, err := engineR.Peek(n)
+		if err != nil {
+			return err
+		}
+		if _, err := client.Write(buf); err != nil {
+			return err
+		}
+		engineR.Discard(n)
+	}
+	if n := clientR.Buffered(); n > 0 {
+		buf, err := clientR.Peek(n)
+		if err != nil {
+			return err
+		}
+		if _, err := engine.Write(buf); err != nil {
+			return err
+		}
+		clientR.Discard(n)
+	}
+	return Relay(client, engine)
+}

--- a/internal/pipeproxy/rewrite_test.go
+++ b/internal/pipeproxy/rewrite_test.go
@@ -1,0 +1,488 @@
+package pipeproxy_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+)
+
+// fakeEngine records the requests it receives so tests can assert on exactly
+// what the proxy forwarded, and replies with whatever the test needs.
+type fakeEngine struct {
+	l net.Listener
+
+	mu   sync.Mutex
+	reqs []*recordedRequest
+
+	// respond writes the reply for request number n (0-based).
+	respond func(n int, w io.Writer, req *http.Request)
+}
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	Body   string
+}
+
+func newFakeEngine(t *testing.T, respond func(n int, w io.Writer, req *http.Request)) *fakeEngine {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	e := &fakeEngine{l: l, respond: respond}
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go e.serve(c)
+		}
+	}()
+	t.Cleanup(func() { l.Close() })
+	return e
+}
+
+func (e *fakeEngine) serve(c net.Conn) {
+	defer c.Close()
+	br := bufio.NewReader(c)
+	for n := 0; ; n++ {
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		body, _ := io.ReadAll(req.Body)
+		req.Body.Close()
+
+		e.mu.Lock()
+		e.reqs = append(e.reqs, &recordedRequest{
+			Method: req.Method, Path: req.URL.Path, Body: string(body),
+		})
+		e.mu.Unlock()
+
+		e.respond(n, c, req)
+	}
+}
+
+func (e *fakeEngine) requests() []*recordedRequest {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]*recordedRequest, len(e.reqs))
+	copy(out, e.reqs)
+	return out
+}
+
+func (e *fakeEngine) dialer() pipeproxy.Dialer {
+	return pipeproxy.DialerFunc(func(ctx context.Context) (io.ReadWriteCloser, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", e.l.Addr().String())
+	})
+}
+
+// okJSON is the ordinary engine reply: a short JSON body, keep-alive.
+func okJSON(body string) func(int, io.Writer, *http.Request) {
+	return func(_ int, w io.Writer, _ *http.Request) {
+		fmt.Fprintf(w, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s",
+			len(body), body)
+	}
+}
+
+// startRewriteProxy runs a Server with the bind-rewriting handler.
+func startRewriteProxy(t *testing.T, d pipeproxy.Dialer) (addr string, stop func()) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &pipeproxy.Server{Dialer: d, Handler: pipeproxy.RewriteBinds}
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx, l) }()
+	return l.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("Serve did not return")
+		}
+	}
+}
+
+// postCreate sends a container-create request through the proxy and returns the
+// response body.
+func postCreate(t *testing.T, addr, path, body string) string {
+	t.Helper()
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	fmt.Fprintf(c, "POST %s HTTP/1.1\r\nHost: docker\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+		path, len(body), body)
+
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	resp, err := io.ReadAll(c)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(resp)
+}
+
+func TestRewriteTranslatesBinds(t *testing.T) {
+	engine := newFakeEngine(t, okJSON(`{"Id":"abc"}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	postCreate(t, addr, "/v1.55/containers/create",
+		`{"Image":"alpine","HostConfig":{"Binds":["C:\\src:/app","myvol:/data"]}}`)
+
+	reqs := engine.requests()
+	if len(reqs) != 1 {
+		t.Fatalf("engine saw %d requests, want 1", len(reqs))
+	}
+
+	var got struct {
+		Image      string
+		HostConfig struct{ Binds []string }
+	}
+	if err := json.Unmarshal([]byte(reqs[0].Body), &got); err != nil {
+		t.Fatalf("engine received invalid JSON %q: %v", reqs[0].Body, err)
+	}
+	want := []string{"/mnt/c/src:/app", "myvol:/data"}
+	if len(got.HostConfig.Binds) != len(want) {
+		t.Fatalf("got binds %v, want %v", got.HostConfig.Binds, want)
+	}
+	for i := range want {
+		if got.HostConfig.Binds[i] != want[i] {
+			t.Errorf("bind %d = %q, want %q", i, got.HostConfig.Binds[i], want[i])
+		}
+	}
+	// Unrelated fields must survive the round-trip.
+	if got.Image != "alpine" {
+		t.Errorf("Image = %q, want alpine", got.Image)
+	}
+}
+
+func TestRewriteTranslatesMountSource(t *testing.T) {
+	engine := newFakeEngine(t, okJSON(`{"Id":"abc"}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	postCreate(t, addr, "/v1.55/containers/create",
+		`{"HostConfig":{"Mounts":[`+
+			`{"Type":"bind","Source":"C:\\data","Target":"/data"},`+
+			`{"Type":"volume","Source":"myvol","Target":"/vol"}]}}`)
+
+	var got struct {
+		HostConfig struct {
+			Mounts []struct {
+				Type, Source, Target string
+			}
+		}
+	}
+	if err := json.Unmarshal([]byte(engine.requests()[0].Body), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got.HostConfig.Mounts[0].Source != "/mnt/c/data" {
+		t.Errorf("bind mount source = %q, want /mnt/c/data", got.HostConfig.Mounts[0].Source)
+	}
+	// A volume's Source is a name, not a path — translating it would convert
+	// the volume into a bind mount.
+	if got.HostConfig.Mounts[1].Source != "myvol" {
+		t.Errorf("volume source = %q, want myvol (untouched)", got.HostConfig.Mounts[1].Source)
+	}
+}
+
+func TestRewritePreservesUnknownFields(t *testing.T) {
+	// The engine API grows every release; dropping a field we don't model
+	// would be a silent behavior change for the user.
+	engine := newFakeEngine(t, okJSON(`{}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	postCreate(t, addr, "/v1.55/containers/create",
+		`{"HostConfig":{"Binds":["C:\\src:/app"],"SomeFutureOption":{"nested":true},"CpuShares":1024},"NewTopLevel":42}`)
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(engine.requests()[0].Body), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["NewTopLevel"] == nil {
+		t.Error("unknown top-level field was dropped")
+	}
+	hc := got["HostConfig"].(map[string]any)
+	if hc["SomeFutureOption"] == nil {
+		t.Error("unknown HostConfig field was dropped")
+	}
+	// Numbers must not gain a float representation (1024 not 1.024e3).
+	if !strings.Contains(engine.requests()[0].Body, "1024") {
+		t.Errorf("numeric literal mangled: %s", engine.requests()[0].Body)
+	}
+}
+
+func TestRewriteLeavesOtherRequestsAlone(t *testing.T) {
+	engine := newFakeEngine(t, okJSON(`{"Version":"29.7.2"}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	body := `{"Binds":["C:\\src:/app"]}` // same shape, but not a create call
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	fmt.Fprintf(c, "POST /v1.55/containers/other HTTP/1.1\r\nHost: d\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+		len(body), body)
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	io.ReadAll(c)
+
+	if got := engine.requests()[0].Body; got != body {
+		t.Errorf("non-create body altered:\n got %s\nwant %s", got, body)
+	}
+}
+
+func TestRewriteHandlesKeepAlive(t *testing.T) {
+	// The docker CLI pools connections, so a second create can arrive on a
+	// connection the proxy has already handled one request on.
+	engine := newFakeEngine(t, func(_ int, w io.Writer, _ *http.Request) {
+		fmt.Fprint(w, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+	})
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	br := bufio.NewReader(c)
+
+	for i := 0; i < 3; i++ {
+		body := fmt.Sprintf(`{"HostConfig":{"Binds":["C:\\src%d:/app"]}}`, i)
+		fmt.Fprintf(c, "POST /v1.55/containers/create HTTP/1.1\r\nHost: d\r\nContent-Length: %d\r\n\r\n%s",
+			len(body), body)
+		c.SetReadDeadline(time.Now().Add(5 * time.Second))
+		resp, err := http.ReadResponse(br, nil)
+		if err != nil {
+			t.Fatalf("request %d: read response: %v", i, err)
+		}
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+
+	reqs := engine.requests()
+	if len(reqs) != 3 {
+		t.Fatalf("engine saw %d requests, want 3", len(reqs))
+	}
+	for i, r := range reqs {
+		want := fmt.Sprintf("/mnt/c/src%d:/app", i)
+		if !strings.Contains(r.Body, want) {
+			t.Errorf("request %d body %s, want it to contain %q", i, r.Body, want)
+		}
+	}
+}
+
+func TestRewriteRejectsUNCBind(t *testing.T) {
+	// A UNC path cannot be bind-mounted; refusing with a real API error beats
+	// forwarding it and letting the daemon fail less legibly.
+	engine := newFakeEngine(t, okJSON(`{}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	resp := postCreate(t, addr, "/v1.55/containers/create",
+		`{"HostConfig":{"Binds":["\\\\server\\share:/app"]}}`)
+
+	if !strings.Contains(resp, "400") {
+		t.Errorf("expected a 400 response, got:\n%s", resp)
+	}
+	if !strings.Contains(resp, "UNC") {
+		t.Errorf("error message should mention UNC, got:\n%s", resp)
+	}
+	if len(engine.requests()) != 0 {
+		t.Errorf("bad request was forwarded to the engine: %+v", engine.requests())
+	}
+}
+
+func TestRewriteFallsBackToRawOn101(t *testing.T) {
+	// docker exec with an upgrade: after 101 the connection is not HTTP, so
+	// the proxy must stop parsing and copy bytes.
+	engine := newFakeEngine(t, func(_ int, w io.Writer, _ *http.Request) {
+		fmt.Fprint(w, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
+		// Now behave like a shell: echo whatever arrives.
+		if c, ok := w.(net.Conn); ok {
+			io.Copy(c, c)
+		}
+	})
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	fmt.Fprint(c, "POST /v1.55/containers/abc/attach?stream=1 HTTP/1.1\r\nHost: d\r\nUpgrade: tcp\r\nConnection: Upgrade\r\nContent-Length: 0\r\n\r\n")
+	br := bufio.NewReader(c)
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("status = %q, want 101", status)
+	}
+	// Drain headers.
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read headers: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	// The stream is raw from here.
+	if _, err := io.WriteString(c, "echo-me"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 7)
+	if _, err := io.ReadFull(br, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf) != "echo-me" {
+		t.Errorf("raw stream = %q, want %q", buf, "echo-me")
+	}
+}
+
+func TestRewriteFallsBackToRawOnRawStream200(t *testing.T) {
+	// Docker does not always answer with 101: without an upgrade request,
+	// attach returns 200 and then streams. Status code alone is not enough.
+	engine := newFakeEngine(t, func(_ int, w io.Writer, _ *http.Request) {
+		fmt.Fprint(w, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.multiplexed-stream\r\n\r\n")
+		if c, ok := w.(net.Conn); ok {
+			io.Copy(c, c)
+		}
+	})
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	fmt.Fprint(c, "POST /v1.55/containers/abc/attach?stream=1 HTTP/1.1\r\nHost: d\r\nContent-Length: 0\r\n\r\n")
+	br := bufio.NewReader(c)
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read head: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+	if _, err := io.WriteString(c, "raw-bytes"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 9)
+	if _, err := io.ReadFull(br, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "raw-bytes" {
+		t.Errorf("got %q, want %q", buf, "raw-bytes")
+	}
+}
+
+func TestRewriteStreamsChunkedResponse(t *testing.T) {
+	// docker logs -f arrives chunked; it must reach the client incrementally
+	// rather than being buffered until the response completes.
+	engine := newFakeEngine(t, func(_ int, w io.Writer, _ *http.Request) {
+		fmt.Fprint(w, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n")
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(w, "7\r\nline-%d\n\r\n", i)
+			time.Sleep(20 * time.Millisecond)
+		}
+		fmt.Fprint(w, "0\r\n\r\n")
+	})
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	fmt.Fprint(c, "GET /v1.55/containers/abc/logs?follow=1 HTTP/1.1\r\nHost: d\r\n\r\n")
+
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	buf := make([]byte, 7)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		t.Fatalf("read first chunk: %v", err)
+	}
+	if string(buf) != "line-0\n" {
+		t.Errorf("first chunk = %q, want %q", buf, "line-0\n")
+	}
+}
+
+func TestRewriteHandlesEmptyAndNonJSONBodies(t *testing.T) {
+	engine := newFakeEngine(t, okJSON(`{}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	// Malformed JSON must be forwarded unchanged so the engine renders the
+	// authoritative error rather than the proxy guessing.
+	garbage := `not json at all`
+	postCreate(t, addr, "/v1.55/containers/create", garbage)
+	if got := engine.requests()[0].Body; got != garbage {
+		t.Errorf("body = %q, want it forwarded unchanged", got)
+	}
+}
+
+func TestRewriteNoHostConfig(t *testing.T) {
+	engine := newFakeEngine(t, okJSON(`{}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	body := `{"Image":"alpine"}`
+	postCreate(t, addr, "/v1.55/containers/create", body)
+	if got := engine.requests()[0].Body; got != body {
+		t.Errorf("body = %q, want %q unchanged", got, body)
+	}
+}
+
+func TestRewriteUnversionedPath(t *testing.T) {
+	// DOCKER_API_VERSION can be unset, in which case the CLI omits the prefix.
+	engine := newFakeEngine(t, okJSON(`{}`))
+	addr, stop := startRewriteProxy(t, engine.dialer())
+	defer stop()
+
+	postCreate(t, addr, "/containers/create", `{"HostConfig":{"Binds":["C:\\src:/app"]}}`)
+	if got := engine.requests()[0].Body; !strings.Contains(got, "/mnt/c/src:/app") {
+		t.Errorf("unversioned path not rewritten: %s", got)
+	}
+}


### PR DESCRIPTION
Closes #6. The other half of the proxy: an HTTP-aware handler that translates Windows bind paths, then gets out of the way.

**What it rewrites** — `HostConfig.Binds` (via `winpath` from #17) and the `Source` of any **bind-type** entry in `HostConfig.Mounts`, which is what `--mount` and compose long syntax emit. A volume''s `Source` is a name, not a path, so it''s left alone.

**Three correctness decisions worth reviewing:**

1. **Unknown fields survive.** The body is decoded into a generic map with `UseNumber()`, not a typed struct. The engine API grows every release, and silently dropping an option the proxy doesn''t model would be far worse than failing to translate a path. `UseNumber` also keeps `1024` from round-tripping into a float.

2. **Hijack detection is not just status 101.** Without an upgrade request, docker answers `exec`/`attach` with **200** and then streams raw bytes — so `application/vnd.docker.raw-stream` and `.multiplexed-stream` content types are detected too. Get this wrong and `docker exec -it` hangs while looking like a network problem.

3. **Buffered bytes are flushed before going raw.** The HTTP readers may already hold the first bytes of the hijacked stream; discarding them would look exactly like a hung `docker exec`. This is the subtle one, and it has a test.

Also handles keep-alive properly — the CLI pools connections, so a second `create` can arrive on a connection already used once, and a "parse the first request then go raw" shortcut would miss it. A UNC bind is refused with an API-shaped 400 rather than forwarded to fail less legibly.

**One API change:** `Server.OnAccept` is replaced by `Server.Handler`. The connection-wrapper shape I added in #18 was speculative and can''t express an HTTP proxy loop; a handler that fully replaces the relay can. Nothing consumed the old hook.

**26 tests in the package, 75% coverage** — including chunked streaming reaching the client incrementally, both hijack paths, keep-alive with three sequential creates, and malformed JSON being forwarded so the engine renders the authoritative error.

Remaining before this is provable end to end: #8 provisioner and #9 CLI wiring, then #11 acceptance runs it against a real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)