### PR TITLE
Spike B kit: session-0 / no-login WSL2 from a service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,18 @@ jobs:
 
       # The Spike A relay is a separate throwaway module — keep it compiling
       # until the real pipeproxy replaces it, then this step goes away.
-      - name: build spike relay
-        working-directory: spike/a/relay
+      # Spikes are separate throwaway modules, kept compiling so they stay
+      # runnable until their issue closes and they are deleted.
+      - name: build spike modules
+        shell: pwsh
         run: |
-          go mod tidy
-          go build ./...
+          Get-ChildItem -Path spike -Recurse -Filter go.mod | ForEach-Object {
+            $dir = $_.Directory.FullName
+            Write-Host "== $dir"
+            Push-Location $dir
+            go mod tidy
+            if ($LASTEXITCODE -ne 0) { Pop-Location; exit 1 }
+            go build ./...
+            if ($LASTEXITCODE -ne 0) { Pop-Location; exit 1 }
+            Pop-Location
+          }

--- a/spike/b/01-preflight.ps1
+++ b/spike/b/01-preflight.ps1
@@ -1,0 +1,62 @@
+# Spike B step 1: baseline in the interactive session, and set up a distro to probe.
+# Establishes what "working" looks like before any service is involved, so a later
+# failure can be attributed to session 0 rather than to the environment.
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+$distro = 'hawser-spike-b'
+
+function Assert-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $p = [Security.Principal.WindowsPrincipal]::new($id)
+    if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "run this from an elevated PowerShell - service and account operations need it"
+    }
+}
+Assert-Admin
+
+Write-Host "== interactive baseline ==" -ForegroundColor Cyan
+"whoami: $(whoami)"
+"session: $((Get-Process -Id $PID).SessionId)   (0 = services session)"
+(wsl --version) -replace "`0","" | Select-Object -First 2
+Write-Host "`ndistros visible to $(whoami):"
+(wsl --list --verbose) -replace "`0","" | Where-Object { $_ -match '\S' }
+
+# Reuse Spike A's rootfs recipe: Alpine + static dockerd. If Spike A's download
+# is still around, use it; otherwise fetch.
+$dl = Join-Path (Split-Path $here -Parent) 'a\dl'
+$alpine = Join-Path $dl 'alpine-minirootfs-3.24.1-x86_64.tar.gz'
+$docker = Join-Path $dl 'docker-29.7.2.tgz'
+if (-not (Test-Path $alpine) -or -not (Test-Path $docker)) {
+    Write-Host "`nfetching rootfs inputs (reusing spike/a/01-fetch.ps1)..." -ForegroundColor Cyan
+    & (Join-Path (Split-Path $here -Parent) 'a\01-fetch.ps1')
+}
+
+if ((wsl --list --quiet) -replace "`0","" | Where-Object { $_.Trim() -eq $distro }) {
+    Write-Host "`ndistro $distro already registered - skipping import" -ForegroundColor Yellow
+} else {
+    Write-Host "`n== importing $distro (as the interactive user) ==" -ForegroundColor Cyan
+    # Deliberately imported as the interactive user: whether a service account
+    # can see this registration is the question the spike exists to answer.
+    $vhd = Join-Path $env:LOCALAPPDATA $distro
+    New-Item -ItemType Directory -Force $vhd | Out-Null
+    wsl --import $distro $vhd $alpine --version 2
+    if ($LASTEXITCODE -ne 0) { throw "wsl --import failed" }
+
+    $setup = (wsl -d $distro --exec wslpath -a (Join-Path (Split-Path $here -Parent) 'a\03-setup.sh')).Trim()
+    $tgz = (wsl -d $distro --exec wslpath -a $docker).Trim()
+    wsl -d $distro -u root --exec sh $setup $tgz
+    if ($LASTEXITCODE -ne 0) { throw "distro setup failed" }
+}
+
+Write-Host "`n== console-mode probe (interactive baseline) ==" -ForegroundColor Cyan
+Push-Location (Join-Path $here 'agent')
+go build -o probe.exe .
+if ($LASTEXITCODE -ne 0) { Pop-Location; throw "probe build failed" }
+Pop-Location
+
+$env:HAWSER_SPIKE_DISTRO = $distro
+& (Join-Path $here 'agent\probe.exe')
+
+Write-Host "`nBaseline recorded. Every check below should be OK before continuing:" -ForegroundColor Cyan
+& (Join-Path $here 'show-log.ps1')
+Write-Host "`nNext: .\02-service-localsystem.ps1" -ForegroundColor Green

--- a/spike/b/02-service-localsystem.ps1
+++ b/spike/b/02-service-localsystem.ps1
@@ -1,0 +1,49 @@
+# Spike B step 2: run the probe as a service under LocalSystem.
+#
+# The cheapest thing that could work, and the most likely to fail: LocalSystem
+# lives in session 0 and has its own registry hive, so the distro the
+# interactive user imported may be invisible. Whichever way it goes, the log
+# says why.
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+$svc = 'HawserSpikeB'
+$exe = Join-Path $here 'agent\probe.exe'
+
+if (-not (Test-Path $exe)) { throw "run 01-preflight.ps1 first (probe.exe missing)" }
+
+if (Get-Service $svc -ErrorAction SilentlyContinue) {
+    Write-Host "removing previous $svc service" -ForegroundColor Yellow
+    sc.exe stop $svc | Out-Null
+    Start-Sleep -Seconds 2
+    sc.exe delete $svc | Out-Null
+    Start-Sleep -Seconds 1
+}
+
+Write-Host "== creating $svc under LocalSystem ==" -ForegroundColor Cyan
+# HAWSER_SPIKE_DISTRO cannot be passed as a service env var without a wrapper,
+# so the probe's built-in default (hawser-spike-b) is what it will use.
+sc.exe create $svc binPath= "`"$exe`"" start= demand obj= "LocalSystem" DisplayName= "Hawser Spike B (LocalSystem)"
+if ($LASTEXITCODE -ne 0) { throw "sc create failed" }
+
+Write-Host "`n== starting ==" -ForegroundColor Cyan
+sc.exe start $svc
+Start-Sleep -Seconds 20
+
+Write-Host "`n== service state ==" -ForegroundColor Cyan
+sc.exe query $svc | Select-String "STATE|WIN32_EXIT_CODE"
+
+Write-Host "`n== probe log ==" -ForegroundColor Cyan
+& (Join-Path $here 'show-log.ps1') -Mode service
+
+Write-Host @"
+
+Read the log above. The decisive line is 'distro-visible':
+
+  ok=true   LocalSystem sees the distro -> session 0 works, this is the simplest
+            viable pattern. Continue to 04 to test the no-login window.
+  ok=false  per-user registration is the blocker (expected). The distro must be
+            imported as whichever account the service runs under - that is what
+            03 tests with a dedicated account.
+
+Next: .\03-service-dedicated-account.ps1
+"@ -ForegroundColor Green

--- a/spike/b/03-service-dedicated-account.ps1
+++ b/spike/b/03-service-dedicated-account.ps1
@@ -1,0 +1,144 @@
+# Spike B step 3: dedicated service account, with the distro imported AS that
+# account.
+#
+# This is the pattern PLAN §09 proposes, and the one most likely to work: if WSL
+# registration is per-user, then the account that runs the service must be the
+# account that owns the distro. Importing as another user is done through a
+# scheduled task, which is the only built-in way to run a command as a local
+# account non-interactively.
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+$svc = 'HawserSpikeB'
+$user = 'hawser-svc'
+$distro = 'hawser-spike-b'
+$exe = Join-Path $here 'agent\probe.exe'
+
+if (-not (Test-Path $exe)) { throw "run 01-preflight.ps1 first (probe.exe missing)" }
+
+# Generated locally, used only for these API calls, never printed or written to
+# disk. A real installer would use a virtual service account or a managed one.
+Add-Type -AssemblyName System.Web
+$pw = [System.Web.Security.Membership]::GeneratePassword(24, 6)
+$sec = ConvertTo-SecureString $pw -AsPlainText -Force
+
+if (-not (Get-LocalUser $user -ErrorAction SilentlyContinue)) {
+    Write-Host "== creating local account $user ==" -ForegroundColor Cyan
+    New-LocalUser -Name $user -Password $sec -PasswordNeverExpires `
+        -AccountNeverExpires -Description "Hawser Spike B service account" | Out-Null
+    # Not added to any group beyond Users: least privilege is part of the test.
+} else {
+    Write-Host "== resetting password for existing $user ==" -ForegroundColor Yellow
+    Set-LocalUser -Name $user -Password $sec
+}
+
+function Grant-ServiceLogonRight([string]$account) {
+    # No PowerShell cmdlet exposes user rights, so secedit is the built-in path.
+    $tmp = Join-Path $env:TEMP "secpol-$PID"
+    New-Item -ItemType Directory -Force $tmp | Out-Null
+    $inf = Join-Path $tmp 'export.inf'
+    $db = Join-Path $tmp 'secedit.sdb'
+    secedit /export /cfg $inf /quiet
+
+    $sid = (Get-LocalUser $account).SID.Value
+    $content = Get-Content $inf
+    $line = $content | Where-Object { $_ -match '^SeServiceLogonRight' }
+    if ($line) {
+        if ($line -match [regex]::Escape($sid)) {
+            Write-Host "  already granted" -ForegroundColor DarkGray
+            Remove-Item $tmp -Recurse -Force
+            return
+        }
+        $new = "$line,*$sid"
+        $content = $content -replace [regex]::Escape($line), $new
+    } else {
+        $content = $content -replace '(\[Privilege Rights\])', "`$1`r`nSeServiceLogonRight = *$sid"
+    }
+    $applied = Join-Path $tmp 'apply.inf'
+    $content | Set-Content $applied -Encoding Unicode
+    secedit /configure /db $db /cfg $applied /areas USER_RIGHTS /quiet
+    Remove-Item $tmp -Recurse -Force
+    Write-Host "  granted SeServiceLogonRight" -ForegroundColor Green
+}
+
+Write-Host "== granting 'log on as a service' ==" -ForegroundColor Cyan
+Grant-ServiceLogonRight $user
+
+# The distro must be registered under the service account's own hive, so the
+# import runs as that account via a one-shot scheduled task.
+Write-Host "`n== importing $distro as $user (via scheduled task) ==" -ForegroundColor Cyan
+$dl = Join-Path (Split-Path $here -Parent) 'a\dl'
+$alpine = Join-Path $dl 'alpine-minirootfs-3.24.1-x86_64.tar.gz'
+$docker = Join-Path $dl 'docker-29.7.2.tgz'
+$setupSh = Join-Path (Split-Path $here -Parent) 'a\03-setup.sh'
+$svcDistro = "$distro-svc"
+$vhd = "C:\ProgramData\hawser-spike-b\$svcDistro"
+
+# The account needs to reach these files, so stage them somewhere readable and
+# grant the account access to its own VHDX directory.
+New-Item -ItemType Directory -Force $vhd | Out-Null
+icacls "C:\ProgramData\hawser-spike-b" /grant "${user}:(OI)(CI)F" /T | Out-Null
+
+$importScript = Join-Path $env:TEMP "hawser-spike-import-$PID.ps1"
+@"
+`$ErrorActionPreference = 'Continue'
+`$log = 'C:\ProgramData\hawser-spike-b\import.log'
+"whoami: `$(whoami)" | Out-File `$log -Append
+"session: `$((Get-Process -Id `$PID).SessionId)" | Out-File `$log -Append
+"distros before:" | Out-File `$log -Append
+(wsl --list --verbose) -replace "``0","" | Out-File `$log -Append
+wsl --import $svcDistro '$vhd' '$alpine' --version 2 2>&1 | Out-File `$log -Append
+"import exit: `$LASTEXITCODE" | Out-File `$log -Append
+`$p = (wsl -d $svcDistro --exec wslpath -a '$setupSh')
+`$t = (wsl -d $svcDistro --exec wslpath -a '$docker')
+wsl -d $svcDistro -u root --exec sh `$p.Trim() `$t.Trim() 2>&1 | Out-File `$log -Append
+"setup exit: `$LASTEXITCODE" | Out-File `$log -Append
+"distros after:" | Out-File `$log -Append
+(wsl --list --verbose) -replace "``0","" | Out-File `$log -Append
+"@ | Set-Content $importScript -Encoding UTF8
+
+$taskName = 'HawserSpikeBImport'
+schtasks /Delete /TN $taskName /F 2>$null | Out-Null
+schtasks /Create /TN $taskName /TR "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$importScript`"" `
+    /SC ONCE /ST 23:59 /RU $user /RP $pw /RL LIMITED /F | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "schtasks create failed (account may lack batch logon right)" }
+schtasks /Run /TN $taskName | Out-Null
+
+Write-Host "waiting for import (up to 3 min)..." -ForegroundColor DarkGray
+$deadline = (Get-Date).AddMinutes(3)
+do {
+    Start-Sleep -Seconds 5
+    $state = (schtasks /Query /TN $taskName /FO LIST | Select-String 'Status:').ToString()
+} while ($state -match 'Running' -and (Get-Date) -lt $deadline)
+
+Write-Host "`n== import log (as $user) ==" -ForegroundColor Cyan
+Get-Content 'C:\ProgramData\hawser-spike-b\import.log' -ErrorAction SilentlyContinue | Select-Object -Last 30
+
+Write-Host "`n== creating $svc under $user ==" -ForegroundColor Cyan
+if (Get-Service $svc -ErrorAction SilentlyContinue) {
+    sc.exe stop $svc | Out-Null; Start-Sleep -Seconds 2; sc.exe delete $svc | Out-Null; Start-Sleep -Seconds 1
+}
+# HAWSER_SPIKE_DISTRO defaults to hawser-spike-b, but the service account owns
+# hawser-spike-b-svc, so point the service at that one via the registry.
+sc.exe create $svc binPath= "`"$exe`"" start= demand obj= ".\$user" password= "$pw" DisplayName= "Hawser Spike B (dedicated account)" | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "sc create failed" }
+$key = "HKLM:\SYSTEM\CurrentControlSet\Services\$svc"
+Set-ItemProperty $key -Name Environment -Value @("HAWSER_SPIKE_DISTRO=$svcDistro") -Type MultiString
+
+$pw = $null  # drop it from this session
+
+Write-Host "`n== starting ==" -ForegroundColor Cyan
+sc.exe start $svc
+Start-Sleep -Seconds 30
+sc.exe query $svc | Select-String "STATE|WIN32_EXIT_CODE"
+
+Write-Host "`n== probe log ==" -ForegroundColor Cyan
+& (Join-Path $here 'show-log.ps1') -Mode service
+
+Write-Host @"
+
+If 'distro-visible' and 'socket-up' are both ok=true here, the dedicated-account
+pattern works and the CI claim holds. Then run 04 to prove it survives with
+nobody logged in - that is the part that actually matters.
+
+Next: .\04-nologin-window.ps1
+"@ -ForegroundColor Green

--- a/spike/b/04-nologin-window.ps1
+++ b/spike/b/04-nologin-window.ps1
@@ -1,0 +1,40 @@
+# Spike B step 4: the check that actually decides the gate.
+#
+# Everything before this ran while a user was logged in. The claim under test is
+# "works with no user logged in", and the only honest way to test it is to log
+# off, leave the service running, and read the heartbeat afterwards.
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+$svc = 'HawserSpikeB'
+
+$s = Get-Service $svc -ErrorAction SilentlyContinue
+if (-not $s) { throw "no $svc service - run 02 or 03 first" }
+if ($s.Status -ne 'Running') { throw "$svc is $($s.Status); start it before logging off" }
+
+# Survive a reboot too, which is the CI-runner case: the machine comes up and
+# nobody logs in at all.
+sc.exe config $svc start= auto | Out-Null
+Write-Host "$svc set to automatic start (survives reboot)" -ForegroundColor Green
+
+$marker = 'C:\ProgramData\hawser-spike-b\nologin-start.txt'
+(Get-Date).ToString('o') | Set-Content $marker
+
+Write-Host @"
+
+== Now do this by hand ==
+
+  1. SIGN OUT completely (Start > user > Sign out).
+     Do NOT just lock the screen - locking keeps your session alive and proves
+     nothing. RDP disconnect does not count either.
+  2. Leave the machine alone for at least 3 minutes.
+  3. Sign back in and run:  .\05-verdict.ps1
+
+Optional, and the stronger test for the CI-runner claim:
+  1. Reboot instead of signing out.
+  2. At the login screen, wait 3 minutes WITHOUT logging in.
+  3. Log in and run .\05-verdict.ps1
+
+The service writes a heartbeat every 15s, so the log will show whether the
+engine stayed reachable while nobody was present. Recorded start of window:
+  $(Get-Content $marker)
+"@ -ForegroundColor Cyan

--- a/spike/b/05-verdict.ps1
+++ b/spike/b/05-verdict.ps1
@@ -1,0 +1,64 @@
+# Spike B step 5: evaluate the no-login window and print the verdict.
+$ErrorActionPreference = 'Stop'
+$log = 'C:\ProgramData\hawser-spike-b\probe.log'
+$marker = 'C:\ProgramData\hawser-spike-b\nologin-start.txt'
+
+if (-not (Test-Path $log)) { throw "no probe log at $log" }
+
+$events = Get-Content $log | ForEach-Object { try { $_ | ConvertFrom-Json } catch {} }
+
+Write-Host "== identity the service ran as ==" -ForegroundColor Cyan
+$events | Where-Object { $_.phase -eq 'identity' -and $_.mode -eq 'service' } |
+    Select-Object -Last 3 | ForEach-Object { "  $($_.user)  session=$($_.session)" }
+
+Write-Host "`n== decisive checks (service mode) ==" -ForegroundColor Cyan
+foreach ($p in 'wsl-status', 'wsl-list', 'distro-visible', 'distro-exec', 'socket-up') {
+    $e = $events | Where-Object { $_.phase -eq $p -and $_.mode -eq 'service' } | Select-Object -Last 1
+    if ($null -eq $e) { Write-Host ("  {0,-16} (not reached)" -f $p) -ForegroundColor DarkGray; continue }
+    $ok = if ($e.ok -eq $true) { 'OK  ' } elseif ($e.ok -eq $false) { 'FAIL' } else { '--  ' }
+    $color = if ($e.ok -eq $true) { 'Green' } elseif ($e.ok -eq $false) { 'Red' } else { 'Gray' }
+    Write-Host ("  {0,-16} {1} {2}" -f $p, $ok, $e.detail) -ForegroundColor $color
+    if ($e.error) { Write-Host "        error: $($e.error)" -ForegroundColor Red }
+}
+
+if (Test-Path $marker) {
+    $start = [datetime]::Parse((Get-Content $marker))
+    Write-Host "`n== no-login window (began $($start.ToString('u'))) ==" -ForegroundColor Cyan
+
+    $beats = $events | Where-Object {
+        $_.phase -eq 'heartbeat' -and $_.time -and ([datetime]::Parse($_.time)) -gt $start
+    }
+    if (-not $beats) {
+        Write-Host "  no heartbeats after the marker - the service was not running during the window" -ForegroundColor Red
+    } else {
+        $good = ($beats | Where-Object { $_.ok -eq $true }).Count
+        $bad = ($beats | Where-Object { $_.ok -ne $true }).Count
+        $span = ([datetime]::Parse(($beats | Select-Object -Last 1).time)) - $start
+        Write-Host "  heartbeats: $good healthy, $bad unhealthy, spanning $([int]$span.TotalMinutes) min"
+        if ($bad -eq 0 -and $good -ge 4) {
+            Write-Host "  engine stayed reachable with no user logged in" -ForegroundColor Green
+        } elseif ($good -gt 0) {
+            Write-Host "  intermittent - inspect the log directly" -ForegroundColor Yellow
+        } else {
+            Write-Host "  engine was NOT reachable during the window" -ForegroundColor Red
+        }
+    }
+} else {
+    Write-Host "`n(no-login window not started - run 04-nologin-window.ps1)" -ForegroundColor DarkGray
+}
+
+Write-Host @"
+
+== Verdict for issue #3 ==
+
+GO   if distro-visible, distro-exec and socket-up are OK in service mode AND
+     the no-login window shows healthy heartbeats. Record which pattern worked
+     (LocalSystem from 02, or dedicated account from 03) - that decides what
+     `hawser install --headless` has to do in v0.2.
+
+NO-GO / PARTIAL if the no-login window fails. That does not kill the project:
+     it demotes "no user logged in" from a headline claim to "requires auto-logon",
+     and PLAN section 06 gets rewritten honestly before v0.1 publishes.
+
+Paste this output into issue #3, then run .\99-cleanup.ps1
+"@ -ForegroundColor Cyan

--- a/spike/b/99-cleanup.ps1
+++ b/spike/b/99-cleanup.ps1
@@ -1,0 +1,40 @@
+# Spike B cleanup: remove the service, task, account, distros, and logs.
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+
+Write-Host "== service ==" -ForegroundColor Cyan
+sc.exe stop HawserSpikeB 2>$null | Out-Null
+Start-Sleep -Seconds 2
+sc.exe delete HawserSpikeB 2>$null | Out-Null
+
+Write-Host "== scheduled task ==" -ForegroundColor Cyan
+schtasks /Delete /TN HawserSpikeBImport /F 2>$null | Out-Null
+
+Write-Host "== distros ==" -ForegroundColor Cyan
+foreach ($d in 'hawser-spike-b', 'hawser-spike-b-svc') {
+    wsl --terminate $d 2>$null | Out-Null
+    wsl --unregister $d 2>$null | Out-Null
+}
+# The service account owns its own registration, which the interactive user
+# cannot unregister; removing the account and its profile takes it with them.
+
+Write-Host "== local account ==" -ForegroundColor Cyan
+if (Get-LocalUser hawser-svc -ErrorAction SilentlyContinue) {
+    Remove-LocalUser -Name hawser-svc
+    Write-Host "  removed hawser-svc" -ForegroundColor Green
+}
+# Its profile directory, if a logon ever created one.
+Get-CimInstance Win32_UserProfile -ErrorAction SilentlyContinue |
+    Where-Object { $_.LocalPath -like '*hawser-svc*' } |
+    ForEach-Object { Remove-CimInstance $_ -ErrorAction SilentlyContinue }
+
+Write-Host "== files ==" -ForegroundColor Cyan
+Remove-Item -Recurse -Force 'C:\ProgramData\hawser-spike-b' -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force (Join-Path $env:LOCALAPPDATA 'hawser-spike-b') -ErrorAction SilentlyContinue
+Remove-Item -Force (Join-Path $here 'agent\probe.exe') -ErrorAction SilentlyContinue
+Get-ChildItem $env:TEMP -Filter 'hawser-spike-import-*.ps1' -ErrorAction SilentlyContinue | Remove-Item -Force
+
+Write-Host "`nSpike B cleanup done. Verify nothing is left:" -ForegroundColor Green
+Write-Host "  distros:" -ForegroundColor DarkGray
+(wsl --list --quiet) -replace "`0","" | Where-Object { $_ -match '\S' } | ForEach-Object { "    $_" }
+Write-Host "  SeServiceLogonRight may still list a stale SID; harmless once the account is gone." -ForegroundColor DarkGray

--- a/spike/b/README.md
+++ b/spike/b/README.md
@@ -1,0 +1,84 @@
+# Spike B — session-0 / no-login WSL2 from a Windows service (issue #3)
+
+**The gate this decides.** PLAN §06 sells Hawser to self-hosted Windows CI runners, and
+the differentiating claim there is *"works with no user logged in"* — something Docker
+Desktop never solved. If that claim is false, the wedge market narrows and PLAN §06 needs
+rewriting before v0.1 goes public. This spike settles it now rather than at v1.0.
+
+**The specific suspicion.** WSL2 registers distros **per user**, under
+`HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss`. A service runs in session 0 with
+its own hive, so the distro the installing user imported may simply not exist as far as
+the service is concerned. That is the first thing the probe reports, because if it fails
+everything downstream is moot — and the fix (import the distro *as the service account*)
+changes what `hawser install --headless` has to do.
+
+## Requirements
+
+- **Elevated PowerShell** — services, local accounts, and user rights all need it
+- Go on PATH (`winget install GoLang.Go`)
+- Willingness to **sign out** of the machine for ~3 minutes, or reboot without logging in
+
+## Run order
+
+```powershell
+# elevated
+.\01-preflight.ps1               # interactive baseline + a distro to probe
+.\02-service-localsystem.ps1     # cheapest pattern: LocalSystem
+.\03-service-dedicated-account.ps1  # PLAN's proposed pattern: dedicated account
+.\04-nologin-window.ps1          # then SIGN OUT (or reboot, no login) for 3+ min
+.\05-verdict.ps1                 # after signing back in
+.\99-cleanup.ps1                 # removes service, task, account, distros, logs
+```
+
+`show-log.ps1` renders the probe log at any point; `-Mode service` filters to service runs.
+
+## How it answers the question
+
+`agent/` is a small Go program that runs either as a console app (the interactive
+baseline) or as a Windows service, appending JSON lines to
+`C:\ProgramData\hawser-spike-b\probe.log`. It records, in order:
+
+| phase | question |
+|---|---|
+| `identity` | which account, and which session — **0 means the services session** |
+| `wsl-status` | does `wsl.exe` run at all in this context? |
+| `wsl-list` | which distros does *this account* see? |
+| `distro-visible` | is the target distro there? **the decisive line** |
+| `distro-exec` | can the distro actually start and run a command? |
+| `socket-up` | does dockerd come up, and how fast? |
+| `heartbeat` | every 15s: is the socket still reachable? |
+
+The heartbeat is the whole design. Nothing can be observed live while no user is logged
+in, so the service records health continuously and `05-verdict.ps1` reads back what
+happened during the window after you sign in again.
+
+## Record in issue #3
+
+- [ ] Which pattern worked: LocalSystem, dedicated account, or neither
+- [ ] `identity` output — account and session number in service mode
+- [ ] `wsl-list` in service mode: does a service account see the interactive user's distros?
+- [ ] Whether importing *as the service account* was required
+- [ ] Heartbeat result across the sign-out window (and across a reboot with no login, if run)
+- [ ] dockerd cold-start time from `socket-up`
+- [ ] Anything that needed manual intervention — each one is a v0.2 task
+
+## Verdict
+
+**GO** — service-mode checks pass and heartbeats stay healthy with nobody logged in.
+Record which pattern worked; that becomes the v0.2 service design.
+
+**NO-GO / PARTIAL** — the no-login window fails. This does not kill the project: it
+demotes the claim to "requires auto-logon", PLAN §06 is rewritten honestly, and the
+fleet-deployment story leans on MSI + version pinning instead.
+
+## Notes
+
+- The dedicated account is created with a random password that is never printed or
+  written to disk. It is passed to `sc.exe` and `schtasks`, so it is briefly visible in
+  a process command line — acceptable for a throwaway spike, not a pattern for the
+  product. A real installer should prefer a virtual service account
+  (`NT SERVICE\HawserEngine`) or a Group Managed Service Account.
+- The account is deliberately **not** added to Administrators; whether least privilege
+  is sufficient is part of what is being measured.
+- `99-cleanup.ps1` cannot unregister a distro owned by another account directly, so it
+  removes the account and its profile, which takes the registration with it.

--- a/spike/b/agent/go.mod
+++ b/spike/b/agent/go.mod
@@ -1,0 +1,5 @@
+module github.com/zcsizmadia/hawser/spike/b/agent
+
+go 1.23
+
+require golang.org/x/sys v0.30.0

--- a/spike/b/agent/go.sum
+++ b/spike/b/agent/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/spike/b/agent/main.go
+++ b/spike/b/agent/main.go
@@ -1,0 +1,240 @@
+// Spike B probe: answers whether WSL2 and dockerd can run from a Windows
+// service with nobody logged in (issue #3).
+//
+// Runs either as a console program (for a baseline in the interactive session)
+// or as a Windows service, and appends JSON lines to a log both SYSTEM and the
+// interactive user can read. The heartbeat is the point: it records socket
+// health every few seconds, so after logging off and back on the log shows
+// what happened during the window when no user was present — which is the one
+// thing you cannot observe live.
+//
+// Throwaway spike code. Not product quality, deliberately dependency-light.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+const (
+	serviceName = "HawserSpikeB"
+	logDir      = `C:\ProgramData\hawser-spike-b`
+)
+
+// distro is the WSL distribution to probe, from HAWSER_SPIKE_DISTRO.
+func distro() string {
+	if d := os.Getenv("HAWSER_SPIKE_DISTRO"); d != "" {
+		return d
+	}
+	return "hawser-spike-b"
+}
+
+type event struct {
+	Time    string `json:"time"`
+	Phase   string `json:"phase"`
+	Mode    string `json:"mode"`
+	User    string `json:"user,omitempty"`
+	Session uint32 `json:"session,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Output  string `json:"output,omitempty"`
+	Err     string `json:"error,omitempty"`
+	OK      *bool  `json:"ok,omitempty"`
+}
+
+var mode = "console"
+
+func logEvent(e event) {
+	e.Time = time.Now().Format(time.RFC3339)
+	e.Mode = mode
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(logDir, "probe.log"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	b, _ := json.Marshal(e)
+	f.Write(append(b, '\n'))
+}
+
+func boolp(b bool) *bool { return &b }
+
+// identity records who we are and which session we are in. Session 0 is the
+// non-interactive services session — seeing it here is the whole point.
+func identity() (string, uint32) {
+	var user string
+	if t, err := windows.OpenCurrentProcessToken(); err == nil {
+		defer t.Close()
+		if u, err := t.GetTokenUser(); err == nil {
+			if account, domain, _, err := u.User.Sid.LookupAccount(""); err == nil {
+				user = domain + `\` + account
+			} else {
+				user = u.User.Sid.String()
+			}
+		}
+	}
+	// Session 0 is the services session; an interactive login is 1 or higher.
+	var session uint32
+	windows.ProcessIdToSessionId(uint32(os.Getpid()), &session)
+	return user, session
+}
+
+// run executes a command and returns combined output, trimmed for the log.
+func run(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	s := strings.TrimSpace(string(out))
+	// wsl.exe emits UTF-16; strip NULs so the log stays readable.
+	s = strings.ReplaceAll(s, "\x00", "")
+	if len(s) > 4000 {
+		s = s[:4000] + "...(truncated)"
+	}
+	return s, err
+}
+
+// probe runs the questions the spike must answer, in order of increasing
+// dependence on the previous one succeeding.
+func probe() {
+	user, session := identity()
+	logEvent(event{Phase: "identity", User: user, Session: session,
+		Detail: fmt.Sprintf("session %d (0 = non-interactive services session)", session)})
+
+	// 1. Does wsl.exe run at all in this context?
+	out, err := run("wsl.exe", "--status")
+	logEvent(event{Phase: "wsl-status", Output: out, Err: errString(err), OK: boolp(err == nil)})
+
+	// 2. Which distros does THIS account see? Registration lives in HKCU, so a
+	// service account may see none even though the interactive user has several.
+	// If this comes back empty, `hawser install` must import the distro as the
+	// service account rather than as the installing user.
+	out, err = run("wsl.exe", "--list", "--verbose")
+	logEvent(event{Phase: "wsl-list", Output: out, Err: errString(err), OK: boolp(err == nil)})
+
+	d := distro()
+	visible := err == nil && strings.Contains(out, d)
+	logEvent(event{Phase: "distro-visible", Detail: d, OK: boolp(visible)})
+	if !visible {
+		logEvent(event{Phase: "conclusion",
+			Detail: "target distro not visible in this account - per-user registration confirmed as the blocker",
+			OK:     boolp(false)})
+		return
+	}
+
+	// 3. Can we start the distro and reach a shell?
+	out, err = run("wsl.exe", "-d", d, "-u", "root", "--exec", "echo", "alive")
+	logEvent(event{Phase: "distro-exec", Output: out, Err: errString(err), OK: boolp(err == nil)})
+	if err != nil {
+		return
+	}
+
+	// 4. Start dockerd if it is not already running.
+	out, _ = run("wsl.exe", "-d", d, "-u", "root", "--exec", "sh", "-c", "pgrep dockerd || echo none")
+	if strings.Contains(out, "none") {
+		go run("wsl.exe", "-d", d, "-u", "root", "--exec", "sh", "-c",
+			"dockerd >/var/log/dockerd.log 2>&1")
+		logEvent(event{Phase: "dockerd-start", Detail: "launched"})
+	} else {
+		logEvent(event{Phase: "dockerd-start", Detail: "already running: " + out})
+	}
+
+	// 5. Wait for the socket, recording how long it took.
+	start := time.Now()
+	for i := 0; i < 60; i++ {
+		if _, err := run("wsl.exe", "-d", d, "-u", "root", "--exec",
+			"test", "-S", "/var/run/docker.sock"); err == nil {
+			logEvent(event{Phase: "socket-up",
+				Detail: fmt.Sprintf("after %s", time.Since(start).Round(time.Millisecond)),
+				OK:     boolp(true)})
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	out, _ = run("wsl.exe", "-d", d, "-u", "root", "--exec", "tail", "-30", "/var/log/dockerd.log")
+	logEvent(event{Phase: "socket-up", Output: out, OK: boolp(false)})
+}
+
+// heartbeat records socket health until told to stop. Reading these lines after
+// logging back in is how the no-login window gets evaluated.
+func heartbeat(stop <-chan struct{}) {
+	d := distro()
+	t := time.NewTicker(15 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			logEvent(event{Phase: "heartbeat-stop"})
+			return
+		case <-t.C:
+			_, err := run("wsl.exe", "-d", d, "-u", "root", "--exec",
+				"test", "-S", "/var/run/docker.sock")
+			logEvent(event{Phase: "heartbeat", OK: boolp(err == nil), Err: errString(err)})
+		}
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+type spikeService struct{}
+
+func (spikeService) Execute(args []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	s <- svc.Status{State: svc.StartPending}
+	stop := make(chan struct{})
+
+	logEvent(event{Phase: "service-start"})
+	go func() {
+		probe()
+		heartbeat(stop)
+	}()
+
+	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
+	for c := range r {
+		switch c.Cmd {
+		case svc.Interrogate:
+			s <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			logEvent(event{Phase: "service-stop", Detail: fmt.Sprintf("cmd %d", c.Cmd)})
+			close(stop)
+			s <- svc.Status{State: svc.StopPending}
+			return false, 0
+		}
+	}
+	return false, 0
+}
+
+func main() {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "cannot determine service context:", err)
+		os.Exit(1)
+	}
+
+	if isService {
+		mode = "service"
+		if err := svc.Run(serviceName, spikeService{}); err != nil {
+			logEvent(event{Phase: "service-error", Err: err.Error()})
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Console mode: the interactive baseline to compare the service run against.
+	mode = "console"
+	fmt.Println("running probe in console mode; results ->", filepath.Join(logDir, "probe.log"))
+	probe()
+	fmt.Println("done")
+}

--- a/spike/b/show-log.ps1
+++ b/spike/b/show-log.ps1
@@ -1,0 +1,24 @@
+# Render the probe log readably. Optional -Mode filters to console or service runs.
+param([string]$Mode)
+
+$log = 'C:\ProgramData\hawser-spike-b\probe.log'
+if (-not (Test-Path $log)) { Write-Host "no log yet at $log" -ForegroundColor Yellow; return }
+
+Get-Content $log | ForEach-Object {
+    try { $e = $_ | ConvertFrom-Json } catch { return }
+    if ($Mode -and $e.mode -ne $Mode) { return }
+
+    $flag = if ($e.ok -eq $true) { 'OK  ' } elseif ($e.ok -eq $false) { 'FAIL' } else { '    ' }
+    $color = if ($e.ok -eq $true) { 'Green' } elseif ($e.ok -eq $false) { 'Red' } else { 'Gray' }
+    Write-Host ("{0}  {1,-8} {2,-16} {3}" -f `
+        ([datetime]::Parse($e.time).ToString('HH:mm:ss')), $e.mode, $e.phase, $flag) -NoNewline -ForegroundColor $color
+    $extra = @($e.user, $e.detail) | Where-Object { $_ }
+    if ($e.session -ne $null -and $e.phase -eq 'identity') { $extra += "session=$($e.session)" }
+    Write-Host (" " + ($extra -join '  '))
+    if ($e.error) { Write-Host "      error: $($e.error)" -ForegroundColor Red }
+    if ($e.output) {
+        ($e.output -split "`n" | Select-Object -First 6) | ForEach-Object {
+            Write-Host "      | $($_.TrimEnd())" -ForegroundColor DarkGray
+        }
+    }
+}


### PR DESCRIPTION
Kit for #3, the last gate that can still force a plan change. PLAN §06 sells Hawser to self-hosted Windows CI runners on the claim *"works with no user logged in"* — the thing Docker Desktop never solved. If that''s false, §06 needs rewriting before v0.1 goes public.

**The specific suspicion this is built to test:** WSL2 registers distros **per user**, under `HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss`. A service runs in session 0 with its own hive, so the distro the installing user imported may not exist as far as the service is concerned. The probe reports that first, because everything downstream is moot if it fails — and the fix (import the distro *as the service account*) changes what `hawser install --headless` has to do in v0.2.

**Test matrix, cheapest first:**
- `02` — LocalSystem. Simplest thing that could work, most likely to hit the per-user problem.
- `03` — dedicated account with the distro imported **as that account**, via a one-shot scheduled task (the only built-in way to run a command as a local account non-interactively). Deliberately *not* an administrator: whether least privilege suffices is part of the measurement.
- `04`/`05` — the check that actually decides it.

**Why the heartbeat design.** Nothing can be observed live while no user is logged in, so the service records socket health every 15s and `05-verdict.ps1` reads back what happened during the window after you sign in again. The README is explicit that **locking the screen proves nothing** — it has to be a real sign-out, or better, a reboot with no login at all, which is the actual CI-runner shape.

The probe logs identity and **session number** (0 = services session), `wsl.exe` availability, which distros the account sees, distro exec, and dockerd cold-start time — so a failure says *which* layer failed rather than just "didn''t work".

**Security note:** the dedicated account gets a random password that is never printed or written to disk. It''s passed to `sc.exe`/`schtasks`, so it''s briefly visible in a process command line — fine for a throwaway spike, and the README says plainly that the product should use a virtual service account (`NT SERVICE\...`) or a gMSA instead.

Also generalizes the CI spike-build step to find every spike module rather than naming `spike/a/relay`.

Needs elevation and a sign-out, so it''s yours to run — `spike/b/README.md` has the order and the checklist for #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)