### PR TITLE
internal/wsl: real wsl.exe implementation

### DIFF
--- a/internal/wsl/decode.go
+++ b/internal/wsl/decode.go
@@ -1,0 +1,110 @@
+package wsl
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// decodeOutput converts wsl.exe output to a Go string.
+//
+// wsl.exe writes its *own* messages as UTF-16LE — distro lists, --status,
+// "The operation completed successfully" — while the output of a command run
+// inside a distro comes back as raw UTF-8 bytes. Reading the former as UTF-8
+// yields the familiar "H e l l o" with a NUL between every character, and
+// naively stripping NULs corrupts any genuine binary or multi-byte content.
+//
+// So: honor a BOM when present, otherwise detect UTF-16 by structure rather
+// than by guessing, and fall through to UTF-8 unchanged.
+func decodeOutput(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+
+	// Explicit BOMs are unambiguous.
+	switch {
+	case len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE:
+		return decodeUTF16(b[2:], false)
+	case len(b) >= 2 && b[0] == 0xFE && b[1] == 0xFF:
+		return decodeUTF16(b[2:], true)
+	case len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF:
+		return string(b[3:])
+	}
+
+	if looksUTF16LE(b) {
+		return decodeUTF16(b, false)
+	}
+	return string(b)
+}
+
+// looksUTF16LE reports whether the bytes are structurally UTF-16LE text: an
+// even length, and ASCII-range characters each followed by a zero high byte.
+//
+// The check is conservative on purpose. Valid UTF-8 that merely contains a NUL
+// must not be misread as UTF-16, so this requires the alternating pattern to
+// hold across the sample rather than merely finding NULs anywhere.
+func looksUTF16LE(b []byte) bool {
+	if len(b) < 4 || len(b)%2 != 0 {
+		return false
+	}
+	// A NUL is not legal in UTF-8 text output; without one, this is not UTF-16.
+	if !bytes.Contains(b, []byte{0}) {
+		return false
+	}
+
+	sample := b
+	if len(sample) > 512 {
+		sample = sample[:512]
+		if len(sample)%2 != 0 {
+			sample = sample[:len(sample)-1]
+		}
+	}
+
+	var pairs, zeroHigh int
+	for i := 0; i+1 < len(sample); i += 2 {
+		pairs++
+		if sample[i+1] == 0 {
+			zeroHigh++
+		}
+	}
+	if pairs == 0 {
+		return false
+	}
+	// wsl.exe output is overwhelmingly ASCII, so nearly every high byte is
+	// zero. Requiring a large majority avoids false positives on UTF-8 that
+	// happens to contain an embedded NUL.
+	return zeroHigh*10 >= pairs*8
+}
+
+func decodeUTF16(b []byte, bigEndian bool) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1] // drop a stray trailing byte rather than fail
+	}
+	u := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		if bigEndian {
+			u = append(u, uint16(b[i])<<8|uint16(b[i+1]))
+		} else {
+			u = append(u, uint16(b[i+1])<<8|uint16(b[i]))
+		}
+	}
+	s := string(utf16.Decode(u))
+	if !utf8.ValidString(s) {
+		return string(b)
+	}
+	return s
+}
+
+// cleanLines splits decoded output into trimmed, non-empty lines. wsl.exe pads
+// its table output and mixes line endings, so callers should not parse raw.
+func cleanLines(s string) []string {
+	raw := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(raw))
+	for _, l := range raw {
+		if t := strings.TrimSpace(l); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/wsl/decode_test.go
+++ b/internal/wsl/decode_test.go
@@ -1,0 +1,169 @@
+package wsl
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+// utf16le encodes text the way wsl.exe emits its own messages.
+func utf16le(s string, bom bool) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, 0, len(u)*2+2)
+	if bom {
+		b = append(b, 0xFF, 0xFE)
+	}
+	for _, c := range u {
+		b = append(b, byte(c), byte(c>>8))
+	}
+	return b
+}
+
+func TestDecodeOutputUTF16(t *testing.T) {
+	// The exact shape that produced "T h e   o p e r a t i o n" in raw output.
+	want := "The operation completed successfully."
+	for _, bom := range []bool{true, false} {
+		got := decodeOutput(utf16le(want, bom))
+		if got != want {
+			t.Errorf("bom=%v: decodeOutput = %q, want %q", bom, got, want)
+		}
+	}
+}
+
+func TestDecodeOutputUTF16BigEndian(t *testing.T) {
+	want := "Windows Subsystem for Linux"
+	u := utf16.Encode([]rune(want))
+	b := []byte{0xFE, 0xFF}
+	for _, c := range u {
+		b = append(b, byte(c>>8), byte(c))
+	}
+	if got := decodeOutput(b); got != want {
+		t.Errorf("decodeOutput = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeOutputUTF8Passthrough(t *testing.T) {
+	// Output of a command run *inside* a distro is plain UTF-8 and must not be
+	// touched — including non-ASCII, which a NUL-stripping approach mangles.
+	for _, s := range []string{
+		"alive",
+		"Docker version 29.7.2, build 6a43e3d",
+		"héllo wörld",
+		"日本語のテキスト",
+		"",
+	} {
+		if got := decodeOutput([]byte(s)); got != s {
+			t.Errorf("decodeOutput(%q) = %q, want unchanged", s, got)
+		}
+	}
+}
+
+func TestDecodeOutputUTF8WithBOM(t *testing.T) {
+	b := append([]byte{0xEF, 0xBB, 0xBF}, []byte("hello")...)
+	if got := decodeOutput(b); got != "hello" {
+		t.Errorf("decodeOutput = %q, want %q", got, "hello")
+	}
+}
+
+func TestDecodeOutputDoesNotMisreadBinary(t *testing.T) {
+	// Binary content with embedded NULs must not be mistaken for UTF-16; a
+	// container's stdout can legitimately contain arbitrary bytes.
+	binary := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x0D, 0x0A, 0x1A, 0xFF, 0xD8, 0xFF, 0xE0}
+	got := decodeOutput(binary)
+	if got != string(binary) {
+		t.Errorf("binary input altered: %q", got)
+	}
+}
+
+func TestLooksUTF16LE(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{"utf16 ascii text", utf16le("Ubuntu\nStopped", false), true},
+		{"plain utf8", []byte("Ubuntu\nStopped"), false},
+		{"utf8 with one nul", []byte("abc\x00def ghijklmnop"), false},
+		{"too short", []byte{0x41, 0x00}, false},
+		{"odd length", []byte{0x41, 0x00, 0x42}, false},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksUTF16LE(tt.in); got != tt.want {
+				t.Errorf("looksUTF16LE = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanLines(t *testing.T) {
+	in := "  first  \r\n\r\n   second\n\n  \nthird\r\n"
+	got := cleanLines(in)
+	want := []string{"first", "second", "third"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines %q, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseListVerbose(t *testing.T) {
+	// Real shape of `wsl --list --verbose`, including the two-space indent and
+	// the default marker.
+	out := strings.Join([]string{
+		"  NAME                   STATE           VERSION",
+		"* Ubuntu                 Running         2",
+		"  hawser-engine          Stopped         2",
+		"  docker-desktop         Running         2",
+		"  legacy-distro          Stopped         1",
+	}, "\n")
+
+	got := parseListVerbose(out)
+	if len(got) != 4 {
+		t.Fatalf("got %d distros %+v, want 4", len(got), got)
+	}
+
+	if got[0].Name != "Ubuntu" || !got[0].Default || !got[0].Running() || got[0].Version != 2 {
+		t.Errorf("first distro = %+v", got[0])
+	}
+	if got[1].Name != "hawser-engine" || got[1].Default || got[1].Running() {
+		t.Errorf("hawser-engine = %+v", got[1])
+	}
+	if got[3].Version != 1 {
+		t.Errorf("legacy distro version = %d, want 1", got[3].Version)
+	}
+}
+
+func TestParseListVerboseSkipsHeaderAndJunk(t *testing.T) {
+	// A localized header must not become a phantom distro.
+	out := "  NOM                    ÉTAT            VERSION\n* Ubuntu                 Arrêté          2"
+	got := parseListVerbose(out)
+	if len(got) != 1 || got[0].Name != "Ubuntu" {
+		t.Fatalf("got %+v, want just Ubuntu", got)
+	}
+	// State is localized; Running() is false, which is the safe reading.
+	if got[0].Running() {
+		t.Error("localized state should not read as Running")
+	}
+}
+
+func TestParseListVerboseEmpty(t *testing.T) {
+	if got := parseListVerbose(""); len(got) != 0 {
+		t.Errorf("got %+v, want none", got)
+	}
+}
+
+func TestParseListVerboseNameWithSpaces(t *testing.T) {
+	out := "  NAME      STATE     VERSION\n  My Distro 2004      Stopped   2"
+	got := parseListVerbose(out)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+	if got[0].Name != "My Distro 2004" {
+		t.Errorf("name = %q, want %q", got[0].Name, "My Distro 2004")
+	}
+}

--- a/internal/wsl/local.go
+++ b/internal/wsl/local.go
@@ -1,0 +1,246 @@
+package wsl
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Runner executes an external command. It exists so Local can be tested
+// without wsl.exe: every wsl.exe invocation in the product funnels through here.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+	Start(ctx context.Context, name string, args ...string) (stop func(), err error)
+}
+
+// Local drives the real wsl.exe.
+type Local struct {
+	// Exe is the wsl.exe path. Empty resolves through PATH.
+	Exe string
+	// Runner executes commands. Empty uses the real process runner.
+	Runner Runner
+}
+
+// NewLocal returns a Local backed by the real wsl.exe.
+func NewLocal() *Local { return &Local{} }
+
+var _ WSL = (*Local)(nil)
+
+func (l *Local) exe() string {
+	if l.Exe != "" {
+		return l.Exe
+	}
+	return "wsl.exe"
+}
+
+func (l *Local) runner() Runner {
+	if l.Runner != nil {
+		return l.Runner
+	}
+	return execRunner{}
+}
+
+func (l *Local) run(ctx context.Context, args ...string) (string, error) {
+	out, err := l.runner().Run(ctx, l.exe(), args...)
+	text := decodeOutput(out)
+	if err != nil {
+		// wsl.exe puts the useful part in its output, not the exit status.
+		if text != "" {
+			return text, fmt.Errorf("wsl %s: %w: %s",
+				strings.Join(args, " "), err, firstLine(text))
+		}
+		return text, fmt.Errorf("wsl %s: %w", strings.Join(args, " "), err)
+	}
+	return text, nil
+}
+
+func firstLine(s string) string {
+	if lines := cleanLines(s); len(lines) > 0 {
+		return lines[0]
+	}
+	return ""
+}
+
+// versionRe matches the release in `wsl --version` output. The label is
+// localized, so the version pattern is what gets matched, not the words.
+var versionRe = regexp.MustCompile(`(\d+\.\d+\.\d+(?:\.\d+)?)`)
+
+// defaultVersionRe matches the trailing digit of the default-version line.
+var defaultVersionRe = regexp.MustCompile(`:\s*(\d)\s*$`)
+
+// Status reports WSL availability. A missing wsl.exe is reported as
+// not-installed rather than as an error: the caller's job is to print
+// enable-and-reboot instructions, not to crash (PLAN §05 preflight).
+func (l *Local) Status(ctx context.Context) (Status, error) {
+	var st Status
+
+	if out, err := l.run(ctx, "--version"); err == nil {
+		// First line carries the WSL release; later lines are kernel, WSLg etc.
+		if lines := cleanLines(out); len(lines) > 0 {
+			if m := versionRe.FindStringSubmatch(lines[0]); m != nil {
+				st.Version = m[1]
+			}
+		}
+		st.Installed = true
+	}
+
+	out, err := l.run(ctx, "--status")
+	if err != nil {
+		if !st.Installed {
+			// Neither command worked: treat WSL as absent, not as a failure.
+			return Status{}, nil
+		}
+		return st, nil
+	}
+	st.Installed = true
+
+	for _, line := range cleanLines(out) {
+		if m := defaultVersionRe.FindStringSubmatch(line); m != nil {
+			if v, convErr := strconv.Atoi(m[1]); convErr == nil {
+				st.DefaultVersion = v
+			}
+		}
+	}
+	return st, nil
+}
+
+// Import registers a distro as WSL 2 from a rootfs tarball.
+func (l *Local) Import(ctx context.Context, distro, installDir, rootfsPath string) error {
+	if distro == "" || installDir == "" || rootfsPath == "" {
+		return fmt.Errorf("wsl: Import needs distro, installDir and rootfsPath")
+	}
+	_, err := l.run(ctx, "--import", distro, installDir, rootfsPath, "--version", "2")
+	return err
+}
+
+// Unregister removes a distro and deletes its VHDX. Irreversible.
+func (l *Local) Unregister(ctx context.Context, distro string) error {
+	if distro == "" {
+		return fmt.Errorf("wsl: Unregister needs a distro name")
+	}
+	_, err := l.run(ctx, "--unregister", distro)
+	return err
+}
+
+// Terminate stops a running distro, leaving it registered.
+func (l *Local) Terminate(ctx context.Context, distro string) error {
+	if distro == "" {
+		return fmt.Errorf("wsl: Terminate needs a distro name")
+	}
+	_, err := l.run(ctx, "--terminate", distro)
+	return err
+}
+
+// List returns the distros registered for the current user.
+//
+// Registration is per-user (HKCU\...\Lxss), so this deliberately reports what
+// *this* account can see — the distinction Spike B (#3) exists to measure.
+func (l *Local) List(ctx context.Context) ([]Distro, error) {
+	out, err := l.run(ctx, "--list", "--verbose")
+	if err != nil {
+		// A machine with no distros exits non-zero; that is an empty list.
+		if strings.Contains(strings.ToLower(out), "no installed distributions") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseListVerbose(out), nil
+}
+
+// parseListVerbose reads the `wsl --list --verbose` table.
+//
+// The header is localized, so it is identified by structure (the first line,
+// which never starts with the default marker) rather than by matching English.
+func parseListVerbose(out string) []Distro {
+	lines := cleanLines(out)
+	var distros []Distro
+	for i, line := range lines {
+		isDefault := strings.HasPrefix(line, "*")
+		row := strings.TrimSpace(strings.TrimPrefix(line, "*"))
+		fields := strings.Fields(row)
+		if len(fields) < 3 {
+			continue
+		}
+		// Skip the header row: it is first and has no default marker, and its
+		// last field is not a number.
+		version, err := strconv.Atoi(fields[len(fields)-1])
+		if err != nil {
+			if i == 0 {
+				continue // header
+			}
+			continue
+		}
+		state := fields[len(fields)-2]
+		name := strings.Join(fields[:len(fields)-2], " ")
+		if name == "" {
+			continue
+		}
+		distros = append(distros, Distro{
+			Name: name, State: state, Version: version, Default: isDefault,
+		})
+	}
+	return distros
+}
+
+// Exec runs a command inside a distro and returns its combined output.
+//
+// --exec bypasses the shell, so nothing re-interprets arguments — paths with
+// spaces and shell metacharacters pass through as given.
+func (l *Local) Exec(ctx context.Context, distro, user string, args ...string) (string, error) {
+	if distro == "" {
+		return "", fmt.Errorf("wsl: Exec needs a distro name")
+	}
+	if len(args) == 0 {
+		return "", fmt.Errorf("wsl: Exec needs a command")
+	}
+	return l.run(ctx, append(l.execArgs(distro, user), args...)...)
+}
+
+func (l *Local) execArgs(distro, user string) []string {
+	a := []string{"-d", distro}
+	if user != "" {
+		a = append(a, "-u", user)
+	}
+	return append(a, "--exec")
+}
+
+// Start launches a command inside a distro without waiting for it, for
+// long-lived processes such as dockerd.
+func (l *Local) Start(ctx context.Context, distro, user string, args ...string) (func(), error) {
+	if distro == "" {
+		return nil, fmt.Errorf("wsl: Start needs a distro name")
+	}
+	if len(args) == 0 {
+		return nil, fmt.Errorf("wsl: Start needs a command")
+	}
+	full := append(l.execArgs(distro, user), args...)
+	return l.runner().Start(ctx, l.exe(), full...)
+}
+
+// execRunner runs real processes.
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func (execRunner) Start(ctx context.Context, name string, args ...string) (func(), error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	stopped := make(chan struct{})
+	go func() {
+		cmd.Wait() // reap, so a restarted engine leaves no zombie behind
+		close(stopped)
+	}()
+	return func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+		<-stopped
+	}, nil
+}

--- a/internal/wsl/local_test.go
+++ b/internal/wsl/local_test.go
@@ -1,0 +1,341 @@
+package wsl_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// fakeRunner records invocations and replays canned output, so every wsl.exe
+// argument list the product builds is asserted without WSL being present.
+type fakeRunner struct {
+	calls   [][]string
+	started [][]string
+	// replies maps a joined argument prefix to output.
+	replies map[string]reply
+}
+
+type reply struct {
+	out []byte
+	err error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{replies: map[string]reply{}}
+}
+
+func (f *fakeRunner) on(argPrefix string, out string, err error) *fakeRunner {
+	f.replies[argPrefix] = reply{out: utf16leBytes(out), err: err}
+	return f
+}
+
+func (f *fakeRunner) onRaw(argPrefix string, out []byte, err error) *fakeRunner {
+	f.replies[argPrefix] = reply{out: out, err: err}
+	return f
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, args)
+	joined := strings.Join(args, " ")
+	for prefix, r := range f.replies {
+		if strings.HasPrefix(joined, prefix) {
+			return r.out, r.err
+		}
+	}
+	return nil, errors.New("fakeRunner: no reply for " + joined)
+}
+
+func (f *fakeRunner) Start(_ context.Context, _ string, args ...string) (func(), error) {
+	f.started = append(f.started, args)
+	return func() {}, nil
+}
+
+func (f *fakeRunner) lastCall() []string {
+	if len(f.calls) == 0 {
+		return nil
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// utf16leBytes mimics wsl.exe, which emits its own messages as UTF-16LE.
+func utf16leBytes(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, 0, len(u)*2)
+	for _, c := range u {
+		b = append(b, byte(c), byte(c>>8))
+	}
+	return b
+}
+
+func TestStatusReportsVersionAndDefault(t *testing.T) {
+	r := newFakeRunner().
+		on("--version", "WSL version: 2.7.8.0\nKernel version: 6.6.87.2\nWSLg version: 1.0.66", nil).
+		on("--status", "Default Distribution: Ubuntu\nDefault Version: 2", nil)
+
+	st, err := (&wsl.Local{Runner: r}).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !st.Installed {
+		t.Error("Installed = false, want true")
+	}
+	if st.Version != "2.7.8.0" {
+		t.Errorf("Version = %q, want 2.7.8.0", st.Version)
+	}
+	if st.DefaultVersion != 2 {
+		t.Errorf("DefaultVersion = %d, want 2", st.DefaultVersion)
+	}
+}
+
+func TestStatusMissingWSLIsNotAnError(t *testing.T) {
+	// Preflight's job is to print enable-and-reboot instructions, so a machine
+	// without WSL must report not-installed rather than fail (PLAN §05).
+	r := newFakeRunner().
+		on("--version", "", errors.New("exec: wsl.exe not found")).
+		on("--status", "", errors.New("exec: wsl.exe not found"))
+
+	st, err := (&wsl.Local{Runner: r}).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error for a missing wsl.exe: %v", err)
+	}
+	if st.Installed {
+		t.Error("Installed = true, want false")
+	}
+}
+
+func TestStatusOldBuildWithoutVersionCommand(t *testing.T) {
+	// `wsl --version` postdates `wsl --status`; an older build still works, and
+	// the empty Version is itself the signal that mirrored networking is out.
+	r := newFakeRunner().
+		on("--version", "", errors.New("invalid command line argument")).
+		on("--status", "Default Version: 2", nil)
+
+	st, err := (&wsl.Local{Runner: r}).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !st.Installed {
+		t.Error("Installed = false, want true")
+	}
+	if st.Version != "" {
+		t.Errorf("Version = %q, want empty", st.Version)
+	}
+	if st.DefaultVersion != 2 {
+		t.Errorf("DefaultVersion = %d, want 2", st.DefaultVersion)
+	}
+}
+
+func TestStatusLocalizedDefaultVersion(t *testing.T) {
+	// The label is localized; only the trailing digit is parsed.
+	r := newFakeRunner().
+		on("--version", "WSL-Version: 2.7.8.0", nil).
+		on("--status", "Standardversion: 2", nil)
+
+	st, err := (&wsl.Local{Runner: r}).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.DefaultVersion != 2 {
+		t.Errorf("DefaultVersion = %d, want 2", st.DefaultVersion)
+	}
+}
+
+func TestImportBuildsCorrectArgs(t *testing.T) {
+	r := newFakeRunner().on("--import", "The operation completed successfully.", nil)
+	err := (&wsl.Local{Runner: r}).Import(context.Background(),
+		"hawser-engine", `C:\data\hawser`, `C:\tmp\rootfs.tar.gz`)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	want := []string{"--import", "hawser-engine", `C:\data\hawser`, `C:\tmp\rootfs.tar.gz`, "--version", "2"}
+	got := r.lastCall()
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("args =\n %v\nwant\n %v", got, want)
+	}
+}
+
+func TestImportValidatesArgs(t *testing.T) {
+	l := &wsl.Local{Runner: newFakeRunner()}
+	ctx := context.Background()
+	for _, tc := range [][3]string{
+		{"", "dir", "tar"},
+		{"d", "", "tar"},
+		{"d", "dir", ""},
+	} {
+		if err := l.Import(ctx, tc[0], tc[1], tc[2]); err == nil {
+			t.Errorf("Import(%q,%q,%q) succeeded, want error", tc[0], tc[1], tc[2])
+		}
+	}
+}
+
+func TestErrorIncludesWSLMessage(t *testing.T) {
+	// wsl.exe puts the useful detail in its output, not the exit code, so the
+	// message must be surfaced or diagnosis becomes guesswork.
+	r := newFakeRunner().on("--import",
+		"The supplied file is not a valid distribution.", errors.New("exit status 1"))
+
+	err := (&wsl.Local{Runner: r}).Import(context.Background(), "d", "dir", "tar")
+	if err == nil {
+		t.Fatal("Import succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "not a valid distribution") {
+		t.Errorf("error %q does not include the wsl.exe message", err)
+	}
+}
+
+func TestListParsesDistros(t *testing.T) {
+	r := newFakeRunner().on("--list --verbose", strings.Join([]string{
+		"  NAME             STATE           VERSION",
+		"* Ubuntu           Running         2",
+		"  hawser-engine    Stopped         2",
+	}, "\r\n"), nil)
+
+	got, err := (&wsl.Local{Runner: r}).List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d distros %+v, want 2", len(got), got)
+	}
+	if got[1].Name != "hawser-engine" || got[1].Running() {
+		t.Errorf("hawser-engine = %+v", got[1])
+	}
+}
+
+func TestListNoDistrosIsEmptyNotError(t *testing.T) {
+	// A fresh machine exits non-zero here; that is an empty list, not a fault.
+	r := newFakeRunner().on("--list --verbose",
+		"Windows Subsystem for Linux has no installed distributions.",
+		errors.New("exit status 1"))
+
+	got, err := (&wsl.Local{Runner: r}).List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %+v, want empty", got)
+	}
+}
+
+func TestExecUsesExecToBypassShell(t *testing.T) {
+	r := newFakeRunner().onRaw("-d hawser-engine", []byte("alive"), nil)
+
+	out, err := (&wsl.Local{Runner: r}).Exec(context.Background(),
+		"hawser-engine", "root", "echo", "alive")
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if out != "alive" {
+		t.Errorf("output = %q, want %q", out, "alive")
+	}
+
+	want := []string{"-d", "hawser-engine", "-u", "root", "--exec", "echo", "alive"}
+	if strings.Join(r.lastCall(), "|") != strings.Join(want, "|") {
+		t.Errorf("args = %v, want %v", r.lastCall(), want)
+	}
+}
+
+func TestExecOmitsUserWhenEmpty(t *testing.T) {
+	r := newFakeRunner().onRaw("-d d", []byte("ok"), nil)
+	if _, err := (&wsl.Local{Runner: r}).Exec(context.Background(), "d", "", "true"); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	got := strings.Join(r.lastCall(), " ")
+	if strings.Contains(got, "-u") {
+		t.Errorf("args %q should not contain -u when user is empty", got)
+	}
+}
+
+func TestExecPreservesArgumentsVerbatim(t *testing.T) {
+	// --exec means no shell re-interprets these; a path with spaces and a glob
+	// must arrive unchanged.
+	r := newFakeRunner().onRaw("-d d", []byte(""), nil)
+	args := []string{"sh", "-c", "echo 'a b' > /mnt/c/Program Files/x; ls *"}
+	if _, err := (&wsl.Local{Runner: r}).Exec(context.Background(), "d", "root", args...); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	got := r.lastCall()
+	tail := got[len(got)-len(args):]
+	for i := range args {
+		if tail[i] != args[i] {
+			t.Errorf("arg %d = %q, want %q", i, tail[i], args[i])
+		}
+	}
+}
+
+func TestExecValidates(t *testing.T) {
+	l := &wsl.Local{Runner: newFakeRunner()}
+	if _, err := l.Exec(context.Background(), "", "root", "true"); err == nil {
+		t.Error("Exec with no distro succeeded, want error")
+	}
+	if _, err := l.Exec(context.Background(), "d", "root"); err == nil {
+		t.Error("Exec with no command succeeded, want error")
+	}
+}
+
+func TestStartDoesNotWait(t *testing.T) {
+	r := newFakeRunner()
+	stop, err := (&wsl.Local{Runner: r}).Start(context.Background(),
+		"hawser-engine", "root", "dockerd")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if stop == nil {
+		t.Fatal("Start returned a nil stop function")
+	}
+	stop()
+
+	if len(r.started) != 1 {
+		t.Fatalf("started %d commands, want 1", len(r.started))
+	}
+	want := []string{"-d", "hawser-engine", "-u", "root", "--exec", "dockerd"}
+	if strings.Join(r.started[0], "|") != strings.Join(want, "|") {
+		t.Errorf("args = %v, want %v", r.started[0], want)
+	}
+}
+
+func TestTerminateAndUnregister(t *testing.T) {
+	r := newFakeRunner().
+		on("--terminate", "ok", nil).
+		on("--unregister", "ok", nil)
+	l := &wsl.Local{Runner: r}
+	ctx := context.Background()
+
+	if err := l.Terminate(ctx, "hawser-engine"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if got := strings.Join(r.lastCall(), " "); got != "--terminate hawser-engine" {
+		t.Errorf("terminate args = %q", got)
+	}
+	if err := l.Unregister(ctx, "hawser-engine"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if got := strings.Join(r.lastCall(), " "); got != "--unregister hawser-engine" {
+		t.Errorf("unregister args = %q", got)
+	}
+
+	if err := l.Terminate(ctx, ""); err == nil {
+		t.Error("Terminate with no name succeeded, want error")
+	}
+	if err := l.Unregister(ctx, ""); err == nil {
+		t.Error("Unregister with no name succeeded, want error")
+	}
+}
+
+func TestCustomExePath(t *testing.T) {
+	r := newFakeRunner().on("--terminate", "ok", nil)
+	l := &wsl.Local{Exe: `C:\Windows\System32\wsl.exe`, Runner: r}
+	if err := l.Terminate(context.Background(), "d"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	// The fake ignores the exe, but this asserts the option is plumbed and the
+	// call still succeeds rather than looking up PATH.
+	if len(r.calls) != 1 {
+		t.Errorf("calls = %d, want 1", len(r.calls))
+	}
+}

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -15,13 +15,35 @@ type WSL interface {
 	Unregister(ctx context.Context, distro string) error
 	// Terminate stops a running distro (wsl --terminate).
 	Terminate(ctx context.Context, distro string) error
-	// List returns registered distro names (wsl --list --quiet).
-	List(ctx context.Context) ([]string, error)
+	// List returns the distros registered for the current user.
+	List(ctx context.Context) ([]Distro, error)
+	// Exec runs a command inside a distro and returns its combined output.
+	// user may be empty for the distro's default user.
+	Exec(ctx context.Context, distro, user string, args ...string) (string, error)
+	// Start launches a long-running command inside a distro without waiting.
+	// The returned stop function terminates it.
+	Start(ctx context.Context, distro, user string, args ...string) (stop func(), err error)
 }
 
 // Status describes the host's WSL capability, from wsl --status and wsl --version.
 type Status struct {
-	Installed      bool
+	// Installed is false when wsl.exe is missing or reports no installation.
+	Installed bool
+	// DefaultVersion is the default WSL version for new distros (1 or 2).
 	DefaultVersion int
-	Version        string // WSL release, e.g. "2.7.8.0"
+	// Version is the WSL release, e.g. "2.7.8.0". Empty on older builds where
+	// `wsl --version` does not exist — which is itself a useful signal, since
+	// mirrored networking and DNS tunneling need a recent WSL.
+	Version string
 }
+
+// Distro is one registered WSL distribution.
+type Distro struct {
+	Name    string
+	State   string // "Running", "Stopped", ...
+	Version int    // WSL 1 or 2
+	Default bool
+}
+
+// Running reports whether the distro is currently up.
+func (d Distro) Running() bool { return d.State == "Running" }

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -7,20 +7,28 @@ import (
 	"github.com/zcsizmadia/hawser/internal/wsl"
 )
 
-// fake proves the interface is implementable without wsl.exe — the pattern
-// every consumer test will use.
-type fake struct{ distros []string }
+// fake proves the interface is implementable by hand without wsl.exe — the
+// pattern consumer packages (provisioner, engine, doctor) use in their tests.
+type fake struct{ distros []wsl.Distro }
 
 func (f *fake) Status(context.Context) (wsl.Status, error) {
 	return wsl.Status{Installed: true, DefaultVersion: 2, Version: "2.7.8.0"}, nil
 }
 func (f *fake) Import(_ context.Context, distro, _, _ string) error {
-	f.distros = append(f.distros, distro)
+	f.distros = append(f.distros, wsl.Distro{Name: distro, State: "Stopped", Version: 2})
 	return nil
 }
 func (f *fake) Unregister(context.Context, string) error { return nil }
 func (f *fake) Terminate(context.Context, string) error  { return nil }
-func (f *fake) List(context.Context) ([]string, error)   { return f.distros, nil }
+func (f *fake) List(context.Context) ([]wsl.Distro, error) {
+	return f.distros, nil
+}
+func (f *fake) Exec(context.Context, string, string, ...string) (string, error) {
+	return "", nil
+}
+func (f *fake) Start(context.Context, string, string, ...string) (func(), error) {
+	return func() {}, nil
+}
 
 var _ wsl.WSL = (*fake)(nil)
 
@@ -36,7 +44,16 @@ func TestFakeRoundTrip(t *testing.T) {
 		t.Fatalf("Import() = %v", err)
 	}
 	got, err := w.List(ctx)
-	if err != nil || len(got) != 1 || got[0] != "hawser-engine" {
-		t.Fatalf("List() = %v, %v", got, err)
+	if err != nil || len(got) != 1 || got[0].Name != "hawser-engine" {
+		t.Fatalf("List() = %+v, %v", got, err)
+	}
+}
+
+func TestDistroRunning(t *testing.T) {
+	if !(wsl.Distro{State: "Running"}).Running() {
+		t.Error("Running state should report Running")
+	}
+	if (wsl.Distro{State: "Stopped"}).Running() {
+		t.Error("Stopped state should not report Running")
 	}
 }


### PR DESCRIPTION
Fills in `internal/wsl`, which was interface-only since #13. Everything in v0.1 that touches WSL — the provisioner (#8), engine lifecycle, doctor — depends on this, so it went first among the Spike-B-independent work.

**The load-bearing detail is output encoding**, and it is the kind of thing that produces baffling bugs later. `wsl.exe` writes its **own** messages as UTF-16LE — distro lists, `--status`, "The operation completed successfully" — while the output of a command run *inside* a distro comes back as raw UTF-8. Reading the former as UTF-8 gives the `T h e   o p e r a t i o n` spacing that has already shown up in this project''s own tooling output, and the obvious fix — stripping NULs — silently corrupts genuine binary or multi-byte content.

`decodeOutput` therefore honors a BOM when present, otherwise detects UTF-16 **structurally** (even length, ASCII-with-zero-high-byte across a sample) rather than by hunting for NULs, and passes UTF-8 through untouched. Tests cover both endiannesses, Japanese and accented text, and PNG/JPEG magic bytes that must not be mistaken for UTF-16.

**Other decisions worth a look:**
- **A missing `wsl.exe` is not an error.** `Status` reports not-installed, because preflight''s job is to print enable-and-reboot instructions (PLAN §05), not to crash. An older build without `wsl --version` still reports installed, and the empty `Version` is itself the useful signal that mirrored networking and DNS tunneling are unavailable.
- **Errors carry wsl.exe''s own message.** The exit code says nothing; "The supplied file is not a valid distribution" is the whole diagnosis.
- **Localized output is parsed by structure.** Labels and states are translated, so `Default Version:` is matched by its trailing digit and the list header is identified by shape. A German or French Windows must not produce a phantom distro named `NOM`.
- **`List` reports what *this account* can see**, since registration is per-user under `HKCU\...\Lxss` — the exact distinction Spike B (#3) is measuring.
- **`Exec` uses `--exec`** so no shell re-interprets arguments; a test asserts a path with spaces and a glob arrives verbatim. `Start` is for long-lived processes like dockerd and reaps the child.

**35 tests, 80.8% coverage**, all without WSL thanks to the `Runner` seam. Also ran it against the real `wsl.exe` here: parsed version 2.7.8.0, all four distros with correct states and the default marker, and `Exec` round-tripped UTF-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)