### PR TITLE
internal/provision: preflight, verified install, clean uninstall

### DIFF
--- a/internal/provision/download.go
+++ b/internal/provision/download.go
@@ -1,0 +1,137 @@
+package provision
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Fetcher retrieves the rootfs. The seam exists so tests can serve a tarball
+// without network access, and so a future version can add proxy handling in one
+// place.
+type Fetcher interface {
+	Fetch(ctx context.Context, url string) (io.ReadCloser, error)
+}
+
+// HTTPFetcher retrieves over HTTP(S) using the given client.
+type HTTPFetcher struct{ Client *http.Client }
+
+// Fetch implements Fetcher.
+func (f HTTPFetcher) Fetch(ctx context.Context, url string) (io.ReadCloser, error) {
+	client := f.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("fetching %s: HTTP %s", url, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+// ErrChecksumMismatch reports a rootfs whose contents do not match the expected
+// digest. It is a distinct type because callers must never treat it as a
+// transient failure to retry past: the rootfs becomes root inside the engine VM,
+// so an unverified one is not something to shrug at.
+type ErrChecksumMismatch struct {
+	URL      string
+	Expected string
+	Actual   string
+}
+
+func (e *ErrChecksumMismatch) Error() string {
+	return fmt.Sprintf("rootfs checksum mismatch for %s:\n  expected %s\n  actual   %s\n"+
+		"refusing to import. The download may be corrupt or tampered with; "+
+		"verify the release asset and its published checksum.",
+		e.URL, e.Expected, e.Actual)
+}
+
+// fetchRootfs downloads to dest and verifies its SHA-256 before returning.
+//
+// The download lands on a temporary file that is only renamed into place after
+// verification, so an interrupted or corrupt transfer can never be mistaken for
+// a cached good copy on the next run.
+func (p *Provisioner) fetchRootfs(ctx context.Context, url, wantSHA, dest string) error {
+	if wantSHA == "" {
+		return fmt.Errorf("no expected checksum for %s: refusing to import an unverified rootfs", url)
+	}
+	wantSHA = strings.ToLower(strings.TrimSpace(wantSHA))
+
+	// A verified cached copy is reused; a stale or corrupt one is replaced.
+	if sum, err := fileSHA256(dest); err == nil {
+		if sum == wantSHA {
+			p.logger().Info("rootfs already present and verified", "path", dest)
+			return nil
+		}
+		p.logger().Warn("cached rootfs failed verification, refetching",
+			"path", dest, "expected", wantSHA, "actual", sum)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(dest), err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".rootfs-*.partial")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Removed unless the rename below succeeds, so a failed attempt leaves
+	// nothing behind that a later run could mistake for a complete download.
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName)
+	}()
+
+	body, err := p.fetcher().Fetch(ctx, url)
+	if err != nil {
+		return fmt.Errorf("downloading rootfs: %w", err)
+	}
+	defer body.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), body); err != nil {
+		return fmt.Errorf("downloading rootfs: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("writing rootfs: %w", err)
+	}
+
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != wantSHA {
+		return &ErrChecksumMismatch{URL: url, Expected: wantSHA, Actual: got}
+	}
+
+	if err := os.Rename(tmpName, dest); err != nil {
+		return fmt.Errorf("finalizing rootfs download: %w", err)
+	}
+	p.logger().Info("rootfs downloaded and verified", "path", dest, "sha256", got)
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/provision/preflight.go
+++ b/internal/provision/preflight.go
@@ -1,0 +1,149 @@
+// Package provision installs and removes the Hawser engine distro: preflight,
+// checksum-verified rootfs download, wsl --import, engine start, clean removal.
+package provision
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// MinWSLVersion is the oldest WSL release Hawser is tested against. Older
+// releases may work, but several doctor remedies (mirrored networking, DNS
+// tunneling) do not exist there, so it is reported rather than assumed.
+const MinWSLVersion = "2.0.0"
+
+// Report is the outcome of Preflight: whether install can proceed, and what the
+// user should do if not.
+type Report struct {
+	// OK is true when installation can proceed.
+	OK bool
+	// Problems block installation. Each carries an actionable remedy.
+	Problems []Problem
+	// Warnings do not block installation but limit what will work.
+	Warnings []Problem
+	// Status is what WSL reported, for `hawser version` and doctor output.
+	Status wsl.Status
+	// ExistingDistro is set when the target distro is already registered.
+	ExistingDistro *wsl.Distro
+}
+
+// Problem is a preflight finding plus the fix for it. The remedy is the point:
+// PLAN §05 requires preflight to print exact instructions rather than
+// attempting elevation or failing with a bare error.
+type Problem struct {
+	// Summary states what is wrong, in one line.
+	Summary string
+	// Remedy states what the user should do, concretely.
+	Remedy string
+}
+
+func (p Problem) String() string { return p.Summary + "\n  fix: " + p.Remedy }
+
+// Preflight checks the host before anything is downloaded or written.
+func (p *Provisioner) Preflight(ctx context.Context, opts Options) (Report, error) {
+	opts = opts.withDefaults()
+
+	var r Report
+	status, err := p.wsl().Status(ctx)
+	if err != nil {
+		return r, fmt.Errorf("preflight: querying WSL: %w", err)
+	}
+	r.Status = status
+
+	if !status.Installed {
+		// Deliberately not attempting to enable WSL: it needs elevation and a
+		// reboot, and doing it silently on someone's machine is not our call.
+		r.Problems = append(r.Problems, Problem{
+			Summary: "WSL2 is not installed or not enabled",
+			Remedy: "run `wsl --install --no-distribution` in an elevated prompt, reboot, " +
+				"then run `hawser install` again. If that fails, enable the " +
+				"'Virtual Machine Platform' and 'Windows Subsystem for Linux' Windows " +
+				"features and confirm virtualization is on in firmware.",
+		})
+		return r, nil
+	}
+
+	if status.Version == "" {
+		// `wsl --version` postdates the Store release; its absence means the
+		// inbox WSL, which lacks the networking modes doctor relies on.
+		r.Warnings = append(r.Warnings, Problem{
+			Summary: "cannot determine the WSL version (`wsl --version` unsupported)",
+			Remedy: "install the Store version of WSL (`wsl --update`) for mirrored " +
+				"networking and DNS tunneling, which several VPN fixes need.",
+		})
+	} else if older, cmpErr := versionOlder(status.Version, MinWSLVersion); cmpErr == nil && older {
+		r.Warnings = append(r.Warnings, Problem{
+			Summary: fmt.Sprintf("WSL %s is older than the tested minimum %s",
+				status.Version, MinWSLVersion),
+			Remedy: "run `wsl --update` to get a supported release.",
+		})
+	}
+
+	if status.DefaultVersion == 1 {
+		// Only the default is wrong; Hawser imports with --version 2 anyway, so
+		// this is a warning rather than a blocker.
+		r.Warnings = append(r.Warnings, Problem{
+			Summary: "the default WSL version is 1",
+			Remedy: "Hawser imports its own distro as WSL 2 regardless, but " +
+				"`wsl --set-default-version 2` avoids surprises with your other distros.",
+		})
+	}
+
+	distros, err := p.wsl().List(ctx)
+	if err != nil {
+		return r, fmt.Errorf("preflight: listing distros: %w", err)
+	}
+	for i := range distros {
+		if strings.EqualFold(distros[i].Name, opts.Distro) {
+			d := distros[i]
+			r.ExistingDistro = &d
+			r.Problems = append(r.Problems, Problem{
+				Summary: fmt.Sprintf("distro %q is already registered", opts.Distro),
+				Remedy: fmt.Sprintf("run `hawser uninstall` first, or install under "+
+					"another name with `--distro`. Its data lives in that distro, so "+
+					"%q is never overwritten implicitly.", opts.Distro),
+			})
+		}
+	}
+
+	r.OK = len(r.Problems) == 0
+	return r, nil
+}
+
+// versionOlder compares dotted numeric versions. Returns an error for input it
+// cannot parse, so callers can skip the check instead of guessing.
+func versionOlder(got, min string) (bool, error) {
+	g, err := parseVersion(got)
+	if err != nil {
+		return false, err
+	}
+	m, err := parseVersion(min)
+	if err != nil {
+		return false, err
+	}
+	for i := 0; i < len(g) && i < len(m); i++ {
+		if g[i] != m[i] {
+			return g[i] < m[i], nil
+		}
+	}
+	return len(g) < len(m), nil
+}
+
+func parseVersion(v string) ([]int, error) {
+	parts := strings.Split(strings.TrimSpace(v), ".")
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, fmt.Errorf("unparseable version %q", v)
+	}
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		var n int
+		if _, err := fmt.Sscanf(p, "%d", &n); err != nil {
+			return nil, fmt.Errorf("unparseable version %q", v)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/internal/provision/preflight_test.go
+++ b/internal/provision/preflight_test.go
@@ -1,0 +1,177 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// quietLogger keeps expected-failure tests from filling the test output.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPreflightOKOnHealthyHost(t *testing.T) {
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("not OK: %+v", r.Problems)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %+v", r.Warnings)
+	}
+	if r.Status.Version != "2.7.8.0" {
+		t.Errorf("Status not reported: %+v", r.Status)
+	}
+}
+
+func TestPreflightWSLMissingGivesInstructions(t *testing.T) {
+	// PLAN §05: print the exact enable-and-reboot instructions rather than
+	// attempting elevation.
+	w := &fakeWSL{status: wsl.Status{Installed: false}}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if r.OK {
+		t.Fatal("OK with WSL absent")
+	}
+	if len(r.Problems) != 1 {
+		t.Fatalf("problems = %+v, want exactly 1", r.Problems)
+	}
+	remedy := r.Problems[0].Remedy
+	for _, want := range []string{"wsl --install", "reboot"} {
+		if !strings.Contains(remedy, want) {
+			t.Errorf("remedy should mention %q, got: %s", want, remedy)
+		}
+	}
+}
+
+func TestPreflightWarnsOnMissingVersionCommand(t *testing.T) {
+	// Inbox WSL lacks `wsl --version`, and with it the networking modes several
+	// VPN remedies depend on. A warning, not a blocker.
+	w := &fakeWSL{status: wsl.Status{Installed: true, DefaultVersion: 2}}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("an unknown WSL version should not block install: %+v", r.Problems)
+	}
+	if len(r.Warnings) == 0 {
+		t.Fatal("expected a warning about the unknown WSL version")
+	}
+	if !strings.Contains(r.Warnings[0].Remedy, "wsl --update") {
+		t.Errorf("remedy should suggest wsl --update, got: %s", r.Warnings[0].Remedy)
+	}
+}
+
+func TestPreflightWarnsOnOldWSL(t *testing.T) {
+	w := &fakeWSL{status: wsl.Status{Installed: true, DefaultVersion: 2, Version: "1.2.5"}}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("an old WSL should warn, not block: %+v", r.Problems)
+	}
+	if len(r.Warnings) == 0 {
+		t.Error("expected a warning about the old WSL version")
+	}
+}
+
+func TestPreflightWarnsOnDefaultVersion1(t *testing.T) {
+	// Hawser imports with --version 2 regardless, so this only warns.
+	w := &fakeWSL{status: wsl.Status{Installed: true, DefaultVersion: 1, Version: "2.7.8.0"}}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("default version 1 should not block: %+v", r.Problems)
+	}
+	found := false
+	for _, warn := range r.Warnings {
+		if strings.Contains(warn.Summary, "default WSL version is 1") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %+v, want one about the default version", r.Warnings)
+	}
+}
+
+func TestPreflightDetectsExistingDistroCaseInsensitively(t *testing.T) {
+	// WSL distro names are case-insensitive, so a differently-cased match must
+	// still be caught or the import would collide.
+	w := healthyWSL()
+	w.distros = []wsl.Distro{{Name: "Hawser-Engine", State: "Running", Version: 2}}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if r.OK {
+		t.Error("OK despite a case-differing existing distro")
+	}
+	if r.ExistingDistro == nil {
+		t.Fatal("ExistingDistro not reported")
+	}
+	if !r.ExistingDistro.Running() {
+		t.Errorf("existing distro state not carried: %+v", r.ExistingDistro)
+	}
+}
+
+func TestPreflightIgnoresUnrelatedDistros(t *testing.T) {
+	w := healthyWSL()
+	w.distros = []wsl.Distro{
+		{Name: "Ubuntu", State: "Running", Version: 2},
+		{Name: "docker-desktop", State: "Running", Version: 2},
+	}
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	r, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("unrelated distros should not block install: %+v", r.Problems)
+	}
+}
+
+func TestPreflightPropagatesListError(t *testing.T) {
+	w := healthyWSL()
+	w.listErr = errors.New("wsl.exe exploded")
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	if _, err := p.Preflight(context.Background(), provision.Options{StateDir: t.TempDir()}); err == nil {
+		t.Error("Preflight succeeded despite a list failure")
+	}
+}
+
+func TestProblemStringIncludesRemedy(t *testing.T) {
+	// The remedy is the whole point of the type; it must not be droppable.
+	p := provision.Problem{Summary: "something is wrong", Remedy: "do this"}
+	s := p.String()
+	if !strings.Contains(s, "something is wrong") || !strings.Contains(s, "do this") {
+		t.Errorf("Problem.String() = %q", s)
+	}
+}

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -1,0 +1,332 @@
+package provision
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// DefaultDistro is the WSL distribution Hawser imports. Deliberately distinct
+// so it never collides with a user's own Ubuntu (PLAN §04).
+const DefaultDistro = "hawser-engine"
+
+// EngineSocket is where dockerd listens inside the distro.
+const EngineSocket = "/var/run/docker.sock"
+
+// Options configures an install. Zero values get sensible defaults, so callers
+// only set what they mean to change.
+type Options struct {
+	// Distro is the WSL distribution name. Defaults to DefaultDistro.
+	Distro string
+	// StateDir holds the manifest and the rootfs cache.
+	// Defaults to %LOCALAPPDATA%\Hawser.
+	StateDir string
+	// DataDir is where the distro's VHDX lives. Defaults to StateDir\distro.
+	// Exposed because "move it off C:" is a perennial request (PLAN §03).
+	DataDir string
+	// RootfsURL and RootfsSHA256 identify the rootfs to install. The checksum
+	// is mandatory: an unverified rootfs becomes root inside the engine VM.
+	RootfsURL    string
+	RootfsSHA256 string
+	// EngineVersion is recorded in the manifest for `hawser version`.
+	EngineVersion string
+	// Headless suppresses anything that would wait for a human.
+	Headless bool
+	// StartTimeout bounds the wait for dockerd's socket. Defaults to 60s.
+	StartTimeout time.Duration
+}
+
+func (o Options) withDefaults() Options {
+	if o.Distro == "" {
+		o.Distro = DefaultDistro
+	}
+	if o.StateDir == "" {
+		o.StateDir = defaultStateDir()
+	}
+	if o.DataDir == "" {
+		o.DataDir = filepath.Join(o.StateDir, "distro")
+	}
+	if o.StartTimeout == 0 {
+		o.StartTimeout = 60 * time.Second
+	}
+	return o
+}
+
+func defaultStateDir() string {
+	if base := os.Getenv("LOCALAPPDATA"); base != "" {
+		return filepath.Join(base, "Hawser")
+	}
+	// Non-Windows only happens in tests; keep it deterministic rather than
+	// panicking so the package stays testable everywhere.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "hawser")
+	}
+	return filepath.Join(home, ".hawser")
+}
+
+// Manifest records what an install put on the machine, so uninstall can remove
+// exactly that and `hawser version` can report it without re-deriving anything.
+type Manifest struct {
+	Distro        string    `json:"distro"`
+	DataDir       string    `json:"dataDir"`
+	RootfsURL     string    `json:"rootfsUrl"`
+	RootfsSHA256  string    `json:"rootfsSha256"`
+	EngineVersion string    `json:"engineVersion"`
+	InstalledAt   time.Time `json:"installedAt"`
+	// WSLVersion is what WSL reported at install time, useful when diagnosing
+	// a machine whose WSL was updated afterwards.
+	WSLVersion string `json:"wslVersion,omitempty"`
+}
+
+// Provisioner performs installs and removals.
+type Provisioner struct {
+	// WSL drives wsl.exe. Defaults to the real implementation.
+	WSL wsl.WSL
+	// Fetcher retrieves the rootfs. Defaults to HTTP.
+	Fetcher Fetcher
+	// Logger receives progress. Defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+func (p *Provisioner) wsl() wsl.WSL {
+	if p.WSL != nil {
+		return p.WSL
+	}
+	return wsl.NewLocal()
+}
+
+func (p *Provisioner) fetcher() Fetcher {
+	if p.Fetcher != nil {
+		return p.Fetcher
+	}
+	return HTTPFetcher{}
+}
+
+func (p *Provisioner) logger() *slog.Logger {
+	if p.Logger != nil {
+		return p.Logger
+	}
+	return slog.Default()
+}
+
+// PreflightError reports that installation cannot proceed, carrying every
+// problem so the user sees the full picture rather than one issue per run.
+type PreflightError struct{ Report Report }
+
+func (e *PreflightError) Error() string {
+	msg := "preflight failed:"
+	for _, p := range e.Report.Problems {
+		msg += "\n- " + p.String()
+	}
+	return msg
+}
+
+// Install provisions the engine distro: preflight, verified download, import,
+// then start.
+//
+// It is deliberately not idempotent over an existing distro — preflight refuses
+// when the target is already registered, because that distro holds the user's
+// images and volumes and silently reimporting would destroy them.
+func (p *Provisioner) Install(ctx context.Context, opts Options) (*Manifest, error) {
+	opts = opts.withDefaults()
+	if opts.RootfsURL == "" {
+		return nil, fmt.Errorf("install: RootfsURL is required")
+	}
+
+	report, err := p.Preflight(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, w := range report.Warnings {
+		p.logger().Warn(w.Summary, "fix", w.Remedy)
+	}
+	if !report.OK {
+		return nil, &PreflightError{Report: report}
+	}
+
+	rootfs := filepath.Join(opts.StateDir, "rootfs", filepath.Base(opts.RootfsURL))
+	if err := p.fetchRootfs(ctx, opts.RootfsURL, opts.RootfsSHA256, rootfs); err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(opts.DataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating data dir %s: %w", opts.DataDir, err)
+	}
+
+	p.logger().Info("importing distro", "distro", opts.Distro, "dataDir", opts.DataDir)
+	if err := p.wsl().Import(ctx, opts.Distro, opts.DataDir, rootfs); err != nil {
+		return nil, fmt.Errorf("importing %s: %w", opts.Distro, err)
+	}
+
+	m := &Manifest{
+		Distro:        opts.Distro,
+		DataDir:       opts.DataDir,
+		RootfsURL:     opts.RootfsURL,
+		RootfsSHA256:  opts.RootfsSHA256,
+		EngineVersion: opts.EngineVersion,
+		InstalledAt:   time.Now().UTC(),
+		WSLVersion:    report.Status.Version,
+	}
+	// Written before the engine starts: if start fails, uninstall still knows
+	// what to clean up rather than leaving an orphaned distro behind.
+	if err := p.writeManifest(opts, m); err != nil {
+		return nil, err
+	}
+
+	if err := p.StartEngine(ctx, opts); err != nil {
+		return m, fmt.Errorf("starting engine: %w", err)
+	}
+	return m, nil
+}
+
+// StartEngine launches dockerd and waits for its socket.
+func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
+	opts = opts.withDefaults()
+
+	if running, _ := p.engineRunning(ctx, opts); running {
+		p.logger().Info("engine already running", "distro", opts.Distro)
+		return nil
+	}
+
+	p.logger().Info("starting dockerd", "distro", opts.Distro)
+	// Output goes to a log inside the distro; the caller gets it via
+	// `hawser logs` rather than having it interleaved here.
+	if _, err := p.wsl().Start(ctx, opts.Distro, "root",
+		"sh", "-c", "dockerd >>/var/log/dockerd.log 2>&1"); err != nil {
+		return fmt.Errorf("launching dockerd: %w", err)
+	}
+
+	deadline := time.Now().Add(opts.StartTimeout)
+	for time.Now().Before(deadline) {
+		if running, _ := p.engineRunning(ctx, opts); running {
+			p.logger().Info("engine socket is up", "distro", opts.Distro)
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+
+	// Include the daemon's own last words; without them this is undiagnosable.
+	log, _ := p.wsl().Exec(ctx, opts.Distro, "root", "tail", "-30", "/var/log/dockerd.log")
+	return fmt.Errorf("dockerd did not create %s within %s. Last log lines:\n%s",
+		EngineSocket, opts.StartTimeout, log)
+}
+
+func (p *Provisioner) engineRunning(ctx context.Context, opts Options) (bool, error) {
+	_, err := p.wsl().Exec(ctx, opts.Distro, "root", "test", "-S", EngineSocket)
+	return err == nil, err
+}
+
+// Uninstall removes the distro and Hawser's own state, and nothing else.
+//
+// Best-effort by design: a partially installed machine must still come clean,
+// so a missing distro or absent state directory is not an error. Errors are
+// collected and reported together.
+func (p *Provisioner) Uninstall(ctx context.Context, opts Options) error {
+	opts = opts.withDefaults()
+
+	// A recorded manifest is more trustworthy than the caller's options: it says
+	// where this install actually put things.
+	if m, err := p.ReadManifest(opts); err == nil {
+		if m.Distro != "" {
+			opts.Distro = m.Distro
+		}
+		if m.DataDir != "" {
+			opts.DataDir = m.DataDir
+		}
+	}
+
+	var errs []error
+
+	distros, err := p.wsl().List(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing distros: %w", err))
+	}
+	registered := false
+	for _, d := range distros {
+		if d.Name == opts.Distro {
+			registered = true
+		}
+	}
+
+	if registered {
+		p.logger().Info("terminating distro", "distro", opts.Distro)
+		if err := p.wsl().Terminate(ctx, opts.Distro); err != nil {
+			// Not fatal: unregister stops it anyway.
+			p.logger().Warn("terminate failed, continuing", "error", err)
+		}
+		p.logger().Info("unregistering distro", "distro", opts.Distro)
+		if err := p.wsl().Unregister(ctx, opts.Distro); err != nil {
+			errs = append(errs, fmt.Errorf("unregistering %s: %w", opts.Distro, err))
+		}
+	} else {
+		p.logger().Info("distro not registered, nothing to unregister", "distro", opts.Distro)
+	}
+
+	// Only paths Hawser created. DataDir is removed because wsl --unregister
+	// deletes the VHDX but leaves the directory.
+	if err := os.RemoveAll(opts.DataDir); err != nil {
+		errs = append(errs, fmt.Errorf("removing %s: %w", opts.DataDir, err))
+	}
+	if err := os.Remove(p.manifestPath(opts)); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("removing manifest: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("uninstall completed with errors: %w", errsJoin(errs))
+	}
+	return nil
+}
+
+func errsJoin(errs []error) error {
+	msg := ""
+	for i, e := range errs {
+		if i > 0 {
+			msg += "; "
+		}
+		msg += e.Error()
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func (p *Provisioner) manifestPath(opts Options) string {
+	return filepath.Join(opts.withDefaults().StateDir, "manifest.json")
+}
+
+func (p *Provisioner) writeManifest(opts Options, m *Manifest) error {
+	path := p.manifestPath(opts)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding manifest: %w", err)
+	}
+	if err := os.WriteFile(path, append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+	return nil
+}
+
+// ReadManifest returns what a previous install recorded.
+func (p *Provisioner) ReadManifest(opts Options) (*Manifest, error) {
+	b, err := os.ReadFile(p.manifestPath(opts))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+	return &m, nil
+}

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -1,0 +1,501 @@
+package provision_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// fakeWSL is a scriptable stand-in for wsl.exe.
+type fakeWSL struct {
+	mu sync.Mutex
+
+	status  wsl.Status
+	distros []wsl.Distro
+
+	imported     [][3]string // distro, dir, rootfs
+	started      [][]string
+	terminated   []string
+	unregistered []string
+
+	// socketAlwaysUp models an engine that is already running before we start.
+	socketAlwaysUp bool
+	// socketUpAfter delays the socket by N checks after dockerd is launched,
+	// simulating a daemon that takes a moment to come up.
+	socketUpAfter int
+	socketCalls   int
+
+	importErr error
+	statusErr error
+	listErr   error
+}
+
+func (f *fakeWSL) Status(context.Context) (wsl.Status, error) {
+	return f.status, f.statusErr
+}
+
+func (f *fakeWSL) Import(_ context.Context, distro, dir, rootfs string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.importErr != nil {
+		return f.importErr
+	}
+	f.imported = append(f.imported, [3]string{distro, dir, rootfs})
+	f.distros = append(f.distros, wsl.Distro{Name: distro, State: "Stopped", Version: 2})
+	return nil
+}
+
+func (f *fakeWSL) Unregister(_ context.Context, distro string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unregistered = append(f.unregistered, distro)
+	out := f.distros[:0]
+	for _, d := range f.distros {
+		if d.Name != distro {
+			out = append(out, d)
+		}
+	}
+	f.distros = out
+	return nil
+}
+
+func (f *fakeWSL) Terminate(_ context.Context, distro string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminated = append(f.terminated, distro)
+	return nil
+}
+
+func (f *fakeWSL) List(context.Context) ([]wsl.Distro, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]wsl.Distro, len(f.distros))
+	copy(out, f.distros)
+	return out, nil
+}
+
+func (f *fakeWSL) Exec(_ context.Context, _, _ string, args ...string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(args) >= 2 && args[0] == "test" && args[1] == "-S" {
+		if f.socketAlwaysUp {
+			return "", nil
+		}
+		// No socket until something launched dockerd — the same order a real
+		// machine enforces, so tests cannot accidentally skip the start path.
+		if len(f.started) == 0 {
+			return "", errors.New("exit status 1")
+		}
+		f.socketCalls++
+		if f.socketCalls > f.socketUpAfter {
+			return "", nil
+		}
+		return "", errors.New("exit status 1")
+	}
+	if len(args) > 0 && args[0] == "tail" {
+		return "dockerd log line 1\ndockerd log line 2", nil
+	}
+	return "", nil
+}
+
+func (f *fakeWSL) Start(_ context.Context, _, _ string, args ...string) (func(), error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = append(f.started, args)
+	return func() {}, nil
+}
+
+var _ wsl.WSL = (*fakeWSL)(nil)
+
+func healthyWSL() *fakeWSL {
+	return &fakeWSL{status: wsl.Status{Installed: true, DefaultVersion: 2, Version: "2.7.8.0"}}
+}
+
+// rootfsServer serves a payload and returns its URL and SHA-256.
+func rootfsServer(t *testing.T, payload []byte) (url, sum string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+	h := sha256.Sum256(payload)
+	return srv.URL + "/hawser-rootfs-29.7.2.tar.gz", hex.EncodeToString(h[:])
+}
+
+func testOptions(t *testing.T, url, sum string) provision.Options {
+	t.Helper()
+	dir := t.TempDir()
+	return provision.Options{
+		StateDir:      filepath.Join(dir, "state"),
+		DataDir:       filepath.Join(dir, "data"),
+		RootfsURL:     url,
+		RootfsSHA256:  sum,
+		EngineVersion: "29.7.2",
+		StartTimeout:  2 * time.Second,
+	}
+}
+
+func TestInstallHappyPath(t *testing.T) {
+	url, sum := rootfsServer(t, []byte("pretend rootfs tarball"))
+	w := healthyWSL()
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum)
+
+	m, err := p.Install(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if len(w.imported) != 1 {
+		t.Fatalf("imported %d distros, want 1", len(w.imported))
+	}
+	if got := w.imported[0][0]; got != provision.DefaultDistro {
+		t.Errorf("distro = %q, want %q", got, provision.DefaultDistro)
+	}
+	if got := w.imported[0][1]; got != opts.DataDir {
+		t.Errorf("data dir = %q, want %q", got, opts.DataDir)
+	}
+	// The rootfs must have been downloaded to disk before import.
+	if _, err := os.Stat(w.imported[0][2]); err != nil {
+		t.Errorf("rootfs not on disk at import time: %v", err)
+	}
+	if len(w.started) != 1 {
+		t.Errorf("started %d commands, want 1 (dockerd)", len(w.started))
+	}
+
+	if m.EngineVersion != "29.7.2" || m.WSLVersion != "2.7.8.0" {
+		t.Errorf("manifest = %+v", m)
+	}
+
+	// And it must be readable back, which is what `hawser version` relies on.
+	back, err := p.ReadManifest(opts)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if back.Distro != m.Distro || back.RootfsSHA256 != sum {
+		t.Errorf("manifest round-trip mismatch: %+v vs %+v", back, m)
+	}
+}
+
+func TestInstallRefusesBadChecksum(t *testing.T) {
+	// The rootfs becomes root inside the engine VM, so this must be a hard stop
+	// and must not leave a partial file that a later run could trust.
+	url, _ := rootfsServer(t, []byte("pretend rootfs tarball"))
+	wrong := strings.Repeat("0", 64)
+
+	w := healthyWSL()
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, wrong)
+
+	_, err := p.Install(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Install succeeded with a bad checksum")
+	}
+	var mismatch *provision.ErrChecksumMismatch
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("error = %T (%v), want *ErrChecksumMismatch", err, err)
+	}
+	if len(w.imported) != 0 {
+		t.Error("distro was imported despite the checksum mismatch")
+	}
+
+	// Nothing left behind at all: a partial file could be mistaken for a good
+	// download, and a completed one would be actively dangerous.
+	entries, _ := os.ReadDir(filepath.Join(opts.StateDir, "rootfs"))
+	for _, e := range entries {
+		t.Errorf("file left behind after checksum failure: %q", e.Name())
+	}
+}
+
+func TestInstallRequiresChecksum(t *testing.T) {
+	url, _ := rootfsServer(t, []byte("x"))
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, url, "")
+
+	if _, err := p.Install(context.Background(), opts); err == nil {
+		t.Fatal("Install succeeded with no expected checksum")
+	}
+}
+
+func TestInstallRequiresRootfsURL(t *testing.T) {
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, "", "")
+	if _, err := p.Install(context.Background(), opts); err == nil {
+		t.Fatal("Install succeeded with no rootfs URL")
+	}
+}
+
+func TestInstallRefusesExistingDistro(t *testing.T) {
+	// That distro holds the user's images and volumes; reimporting would
+	// destroy them, so this is a refusal rather than a silent overwrite.
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	w.distros = []wsl.Distro{{Name: provision.DefaultDistro, State: "Stopped", Version: 2}}
+
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	_, err := p.Install(context.Background(), testOptions(t, url, sum))
+	if err == nil {
+		t.Fatal("Install succeeded over an existing distro")
+	}
+	var pfe *provision.PreflightError
+	if !errors.As(err, &pfe) {
+		t.Fatalf("error = %T (%v), want *PreflightError", err, err)
+	}
+	if !strings.Contains(err.Error(), "uninstall") {
+		t.Errorf("error should suggest uninstall, got: %v", err)
+	}
+	if len(w.imported) != 0 {
+		t.Error("import happened despite preflight failure")
+	}
+}
+
+func TestInstallReusesVerifiedCachedRootfs(t *testing.T) {
+	payload := []byte("cached rootfs")
+	var hits int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.Write(payload)
+	}))
+	defer srv.Close()
+	h := sha256.Sum256(payload)
+	sum := hex.EncodeToString(h[:])
+	url := srv.URL + "/rootfs.tar.gz"
+
+	opts := testOptions(t, url, sum)
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	if _, err := p.Install(context.Background(), opts); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Second attempt with a fresh WSL (no distro registered) must not re-download.
+	p2 := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	if _, err := p2.Install(context.Background(), opts); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Errorf("server hit %d times, want 1 (cached copy should be reused)", hits)
+	}
+}
+
+func TestInstallReplacesCorruptCachedRootfs(t *testing.T) {
+	payload := []byte("good rootfs")
+	url, sum := rootfsServer(t, payload)
+	opts := testOptions(t, url, sum)
+
+	// Plant a file with the right name but the wrong contents.
+	cache := filepath.Join(opts.StateDir, "rootfs", filepath.Base(url))
+	if err := os.MkdirAll(filepath.Dir(cache), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cache, []byte("corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	if _, err := p.Install(context.Background(), opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got, err := os.ReadFile(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("cached rootfs = %q, want it replaced with %q", got, payload)
+	}
+}
+
+func TestInstallWritesManifestBeforeEngineStart(t *testing.T) {
+	// If the engine fails to start, uninstall still needs to know what to
+	// clean up, so the manifest must already be on disk.
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	w.socketUpAfter = 1000 // never comes up within the timeout
+
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum)
+	opts.StartTimeout = 500 * time.Millisecond
+
+	m, err := p.Install(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Install succeeded despite the engine never starting")
+	}
+	if m == nil {
+		t.Fatal("Install returned no manifest; uninstall would not know what to remove")
+	}
+	if _, err := p.ReadManifest(opts); err != nil {
+		t.Errorf("manifest not persisted: %v", err)
+	}
+	// The failure must name the daemon log, or it is undiagnosable.
+	if !strings.Contains(err.Error(), "dockerd log line") {
+		t.Errorf("error should include the dockerd log, got: %v", err)
+	}
+}
+
+func TestStartEngineWaitsForSocket(t *testing.T) {
+	w := healthyWSL()
+	w.socketUpAfter = 3 // succeeds on the 4th check
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	opts := provision.Options{StateDir: t.TempDir(), StartTimeout: 5 * time.Second}
+	if err := p.StartEngine(context.Background(), opts); err != nil {
+		t.Fatalf("StartEngine: %v", err)
+	}
+	if len(w.started) != 1 {
+		t.Errorf("started %d commands, want 1", len(w.started))
+	}
+}
+
+func TestStartEngineSkipsWhenAlreadyRunning(t *testing.T) {
+	w := healthyWSL()
+	w.socketAlwaysUp = true
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	opts := provision.Options{StateDir: t.TempDir(), StartTimeout: time.Second}
+	if err := p.StartEngine(context.Background(), opts); err != nil {
+		t.Fatalf("StartEngine: %v", err)
+	}
+	if len(w.started) != 0 {
+		t.Errorf("dockerd was launched even though the socket was already up")
+	}
+}
+
+func TestStartEngineRespectsContextCancel(t *testing.T) {
+	w := healthyWSL()
+	w.socketUpAfter = 1000
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	opts := provision.Options{StateDir: t.TempDir(), StartTimeout: 30 * time.Second}
+	start := time.Now()
+	if err := p.StartEngine(ctx, opts); err == nil {
+		t.Fatal("StartEngine succeeded, want cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %s to honor cancellation", elapsed)
+	}
+}
+
+func TestUninstallRemovesWhatInstallCreated(t *testing.T) {
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum)
+
+	if _, err := p.Install(context.Background(), opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := p.Uninstall(context.Background(), opts); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	if len(w.unregistered) != 1 || w.unregistered[0] != provision.DefaultDistro {
+		t.Errorf("unregistered = %v, want [%s]", w.unregistered, provision.DefaultDistro)
+	}
+	if _, err := os.Stat(opts.DataDir); !os.IsNotExist(err) {
+		t.Errorf("data dir still present: %v", err)
+	}
+	if _, err := p.ReadManifest(opts); err == nil {
+		t.Error("manifest still present after uninstall")
+	}
+}
+
+func TestUninstallOnCleanMachineIsNotAnError(t *testing.T) {
+	// A half-finished or already-removed install must still come clean.
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, "", "")
+	if err := p.Uninstall(context.Background(), opts); err != nil {
+		t.Errorf("Uninstall on a clean machine returned %v, want nil", err)
+	}
+}
+
+func TestUninstallPrefersManifestOverOptions(t *testing.T) {
+	// The manifest records where the install actually went, which matters when
+	// the user installed with --distro or --data-dir and later runs a bare
+	// `hawser uninstall`.
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	opts := testOptions(t, url, sum)
+	opts.Distro = "hawser-custom"
+	if _, err := p.Install(context.Background(), opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Uninstall called without the custom name, as the CLI would by default.
+	bare := provision.Options{StateDir: opts.StateDir}
+	if err := p.Uninstall(context.Background(), bare); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if len(w.unregistered) != 1 || w.unregistered[0] != "hawser-custom" {
+		t.Errorf("unregistered = %v, want [hawser-custom]", w.unregistered)
+	}
+}
+
+func TestFetchRootfsSurfacesHTTPErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, srv.URL+"/missing.tar.gz", strings.Repeat("a", 64))
+
+	_, err := p.Install(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Install succeeded against a 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention the HTTP status, got: %v", err)
+	}
+}
+
+// customFetcher lets a test supply rootfs bytes without a server.
+type customFetcher struct{ payload []byte }
+
+func (c customFetcher) Fetch(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(string(c.payload))), nil
+}
+
+func TestFetcherSeam(t *testing.T) {
+	payload := []byte("rootfs via custom fetcher")
+	h := sha256.Sum256(payload)
+	p := &provision.Provisioner{
+		WSL:     healthyWSL(),
+		Fetcher: customFetcher{payload: payload},
+		Logger:  quietLogger(),
+	}
+	opts := testOptions(t, "https://example.invalid/rootfs.tar.gz", hex.EncodeToString(h[:]))
+
+	if _, err := p.Install(context.Background(), opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+}


### PR DESCRIPTION
Toward #8 — the provisioner behind `hawser install` / `hawser uninstall`. CLI wiring follows in a separate PR; this is the logic, fully tested without WSL or network.

**Preflight refuses rather than repairs.** A missing WSL2 produces the exact enable-and-reboot instructions rather than an elevation attempt — silently flipping Windows features on someone''s machine isn''t our call (PLAN §05). Findings are split into problems (block) and warnings (don''t): an unknown or old WSL only warns, and the *absence* of `wsl --version` is itself the useful signal that mirrored networking and DNS tunneling — which several VPN remedies depend on — aren''t available.

**Install refuses over an existing distro.** That distro holds the user''s images and volumes, so reimporting would destroy them. The remedy names `hawser uninstall` or `--distro`. The check is **case-insensitive**, because WSL distro names are — a `Hawser-Engine` would otherwise collide at import time.

**The download is checksum-mandatory, and that''s the security-critical part.** The rootfs becomes root inside the engine VM:
- a missing expected digest is an error, not a warning — there''s no "install unverified" path
- a mismatch is a typed `ErrChecksumMismatch` so callers can''t treat it as a transient failure to retry past
- the download lands on a **temp file renamed only after verification**, so an interrupted transfer can never be mistaken for a cached good copy next run
- a verified cache is reused (tested: server hit exactly once across two installs); a corrupt one is replaced

**Two ordering decisions worth reviewing:**
1. **The manifest is written before the engine starts.** If start fails, uninstall still knows what to clean up instead of orphaning a distro. There''s a test asserting the manifest survives a failed start, and that the error includes the dockerd log — without which the failure is undiagnosable.
2. **Uninstall prefers the manifest over caller options**, so a bare `hawser uninstall` correctly removes an install made with `--distro` or `--data-dir`. It''s best-effort throughout: a half-installed or already-clean machine must still come clean, so a missing distro isn''t an error.

**25 tests, 81.4% coverage.** The `Fetcher` and `wsl.WSL` seams mean no network or WSL is required; the fake models "no socket until dockerd is launched" so tests can''t accidentally skip the start path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)