### PR TITLE
hawser version --json, and a real CLI entry point

### DIFF
--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -7,14 +7,71 @@ import (
 	"os"
 )
 
-// version is stamped by the release build (-ldflags "-X main.version=...").
-var version = "dev"
+// buildVersion is stamped by the release build (-ldflags "-X main.buildVersion=...").
+var buildVersion = "dev"
+
+// exit codes are part of the CLI contract: CI scripts branch on them, so they
+// are assigned deliberately rather than by accident (PLAN §03).
+const (
+	exitOK       = 0
+	exitError    = 1
+	exitUsage    = 2
+	exitNotFound = 3 // asked about something that is not installed
+)
+
+type command struct {
+	name    string
+	summary string
+	run     func(args []string) int
+}
+
+func commands() []command {
+	return []command{
+		{"version", "report every component version and which docker.exe is active", runVersion},
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprintf(w, `hawser %s - upstream Docker Engine on Windows via WSL2
+
+usage: hawser <command> [flags]
+
+commands:
+`, buildVersion)
+	for _, c := range commands() {
+		fmt.Fprintf(w, "  %-10s %s\n", c.name, c.summary)
+	}
+	fmt.Fprintf(w, `
+Commands still in development are tracked at
+https://github.com/zcsizmadia/hawser/issues
+
+run `+"`hawser <command> --help`"+` for a command's flags
+`)
+}
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "version" {
-		fmt.Printf("hawser %s\n", version)
-		return
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(exitUsage)
 	}
-	fmt.Fprintln(os.Stderr, "hawser: pre-alpha — see PLAN.md and ROADMAP.md")
-	os.Exit(1)
+
+	name := os.Args[1]
+	switch name {
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		os.Exit(exitOK)
+	case "-v", "--version":
+		// Convenience alias; `hawser version` is the real command.
+		name = "version"
+	}
+
+	for _, c := range commands() {
+		if c.name == name {
+			os.Exit(c.run(os.Args[2:]))
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "hawser: unknown command %q\n\n", name)
+	usage(os.Stderr)
+	os.Exit(exitUsage)
 }

--- a/cmd/hawser/version.go
+++ b/cmd/hawser/version.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/version"
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+func runVersion(args []string) int {
+	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit machine-readable JSON")
+	stateDir := fs.String("state-dir", "", "override Hawser's state directory")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser version [--json]
+
+Reports every component version, which docker.exe actually runs, the active
+docker context, and the negotiated engine API version.
+
+Exit codes: 0 ok, %d error, %d no engine installed.
+
+flags:
+`, exitError, exitNotFound)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := provision.Options{StateDir: *stateDir}
+	exe, err := os.Executable()
+	if err != nil {
+		exe = ""
+	}
+
+	c := &version.Collector{
+		App: buildVersion,
+		Env: version.Env{
+			// Hawser's bundled CLI sits beside the binary, which is how its
+			// own docker.exe is recognized on PATH.
+			HawserBin: filepath.Dir(exe),
+		},
+		WSL:         wsl.NewLocal(),
+		Provisioner: &provision.Provisioner{},
+		Options:     opts,
+	}
+
+	report := c.Collect(context.Background())
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+	} else if err := report.WriteText(os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+
+	// A distinct code so `hawser version` doubles as an install check in a
+	// provisioning script, without needing to parse the output.
+	if !report.Engine.Installed {
+		return exitNotFound
+	}
+	return exitOK
+}

--- a/internal/version/collect.go
+++ b/internal/version/collect.go
@@ -1,0 +1,64 @@
+package version
+
+import (
+	"context"
+
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// Collector assembles a Report from the machine. Every source is injectable so
+// the whole thing is testable without WSL, PATH, or an engine.
+type Collector struct {
+	// App is Hawser's own version string.
+	App string
+	// Env supplies PATH and docker config discovery.
+	Env Env
+	// WSL reports the host's WSL release. Optional.
+	WSL wsl.WSL
+	// Provisioner reads the install manifest. Optional.
+	Provisioner *provision.Provisioner
+	// Options locates the manifest.
+	Options provision.Options
+	// ProbeAPI returns the negotiated engine API version. Optional: when nil or
+	// failing, APIVersion is left empty rather than guessed.
+	ProbeAPI func(ctx context.Context) (string, error)
+}
+
+// Collect gathers everything, degrading gracefully. A component that cannot be
+// determined is reported as unknown rather than failing the command: `hawser
+// version` is the first thing someone runs when things are broken, so it must
+// work on a half-installed machine.
+func (c *Collector) Collect(ctx context.Context) *Report {
+	r := &Report{App: c.App}
+
+	if c.WSL != nil {
+		if st, err := c.WSL.Status(ctx); err == nil {
+			r.WSL = st.Version
+		}
+	}
+
+	if c.Provisioner != nil {
+		if m, err := c.Provisioner.ReadManifest(c.Options); err == nil {
+			r.Engine = EngineInfo{
+				Installed:    true,
+				Version:      m.EngineVersion,
+				Distro:       m.Distro,
+				Rootfs:       m.RootfsSHA256,
+				WSLAtInstall: m.WSLVersion,
+			}
+		}
+	}
+
+	r.Docker = FindDockerBinaries(c.Env)
+	r.Context, r.ContextSource = DockerContext(c.Env)
+
+	if c.ProbeAPI != nil {
+		if v, err := c.ProbeAPI(ctx); err == nil {
+			r.APIVersion = v
+		}
+	}
+
+	r.analyze()
+	return r
+}

--- a/internal/version/discover.go
+++ b/internal/version/discover.go
@@ -1,0 +1,201 @@
+// Package version answers "which docker am I actually running?" as a command
+// rather than an archaeology project (PLAN §04).
+//
+// The interesting question is not Hawser's own version but which docker.exe
+// wins on PATH and whose it is. A machine that has had Docker Desktop, winget,
+// Chocolatey and Hawser on it can easily have four, and a stale one resolving
+// first while the hawser context is active produces symptoms that look like
+// Hawser is broken.
+package version
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Origin says who a docker.exe belongs to.
+type Origin string
+
+const (
+	OriginHawser        Origin = "hawser"
+	OriginDockerDesktop Origin = "docker-desktop"
+	OriginRancher       Origin = "rancher-desktop"
+	OriginWinget        Origin = "winget"
+	OriginChocolatey    Origin = "chocolatey"
+	OriginScoop         Origin = "scoop"
+	OriginUnknown       Origin = "unknown"
+)
+
+// Binary is one docker.exe found on PATH.
+type Binary struct {
+	Path   string `json:"path"`
+	Origin Origin `json:"origin"`
+	// First is true for the one that actually runs when the user types `docker`.
+	First bool `json:"first"`
+}
+
+// classify attributes a docker.exe to its owner by install location.
+//
+// Path-based rather than signature-based on purpose: it needs no I/O, works for
+// a binary the user cannot execute, and the answer is only ever advisory — the
+// authoritative facts are the path itself, which is always reported.
+func classify(path, hawserBin string) Origin {
+	p := strings.ToLower(filepath.ToSlash(path))
+
+	if hawserBin != "" {
+		hb := strings.ToLower(filepath.ToSlash(hawserBin))
+		if strings.HasPrefix(p, strings.TrimSuffix(hb, "/")+"/") {
+			return OriginHawser
+		}
+	}
+
+	switch {
+	case strings.Contains(p, "/docker/docker/resources/bin"):
+		return OriginDockerDesktop
+	case strings.Contains(p, "/rancher-desktop/"):
+		return OriginRancher
+	case strings.Contains(p, "/microsoft/winget/"):
+		return OriginWinget
+	case strings.Contains(p, "/chocolatey/"):
+		return OriginChocolatey
+	case strings.Contains(p, "/scoop/"):
+		return OriginScoop
+	case strings.Contains(p, "/hawser/"):
+		return OriginHawser
+	default:
+		return OriginUnknown
+	}
+}
+
+// Env supplies the environment for discovery, so tests need no real PATH.
+type Env struct {
+	// PathVar is the raw PATH value. Empty reads os.Getenv("PATH").
+	PathVar string
+	// PathExt is the raw PATHEXT value; only used to decide executable suffixes.
+	PathExt string
+	// HawserBin is Hawser's own bin directory, used to recognize its binaries.
+	HawserBin string
+	// Getenv reads other variables. Empty uses os.Getenv.
+	Getenv func(string) string
+	// Stat reports whether a path exists. Empty uses os.Stat.
+	Stat func(string) error
+	// UserConfigDir locates ~/.docker. Empty uses os.UserHomeDir.
+	DockerConfigDir string
+}
+
+func (e Env) getenv(k string) string {
+	if e.Getenv != nil {
+		return e.Getenv(k)
+	}
+	return os.Getenv(k)
+}
+
+func (e Env) stat(p string) error {
+	if e.Stat != nil {
+		return e.Stat(p)
+	}
+	_, err := os.Stat(p)
+	return err
+}
+
+func (e Env) pathVar() string {
+	if e.PathVar != "" {
+		return e.PathVar
+	}
+	return e.getenv("PATH")
+}
+
+// FindDockerBinaries returns every docker executable on PATH, in resolution
+// order. The first entry is the one that runs.
+func FindDockerBinaries(env Env) []Binary {
+	var out []Binary
+	seen := map[string]bool{}
+
+	for _, dir := range filepath.SplitList(env.pathVar()) {
+		if dir == "" {
+			continue
+		}
+		// One entry per directory: PATH resolution picks a single file per
+		// directory, so reporting both docker.exe and an extensionless docker
+		// from the same place (as Docker Desktop ships) would be noise dressed
+		// up as a second installation.
+		if seen[strings.ToLower(dir)] {
+			continue
+		}
+		for _, name := range dockerNames(env) {
+			candidate := filepath.Join(dir, name)
+			if err := env.stat(candidate); err != nil {
+				continue
+			}
+			seen[strings.ToLower(dir)] = true
+			out = append(out, Binary{
+				Path:   candidate,
+				Origin: classify(candidate, env.HawserBin),
+				First:  len(out) == 0,
+			})
+			break
+		}
+	}
+	return out
+}
+
+// dockerNames returns the filenames to look for. Windows resolves by PATHEXT;
+// elsewhere (tests, and any future host) the bare name is correct.
+func dockerNames(env Env) []string {
+	exts := env.PathExt
+	if exts == "" {
+		exts = env.getenv("PATHEXT")
+	}
+	if exts == "" {
+		return []string{"docker.exe", "docker"}
+	}
+	names := make([]string, 0, 4)
+	for _, e := range filepath.SplitList(exts) {
+		if e == "" {
+			continue
+		}
+		if strings.EqualFold(e, ".EXE") || strings.EqualFold(e, ".COM") {
+			names = append(names, "docker"+strings.ToLower(e))
+		}
+	}
+	if len(names) == 0 {
+		names = append(names, "docker.exe")
+	}
+	return append(names, "docker")
+}
+
+// DockerContext reports the active docker context and how it was selected.
+//
+// Order matters and mirrors the docker CLI: DOCKER_HOST overrides everything
+// (and means no context is in play), then DOCKER_CONTEXT, then the CLI config's
+// currentContext, then the implicit default.
+func DockerContext(env Env) (name, source string) {
+	if h := env.getenv("DOCKER_HOST"); h != "" {
+		return "", "DOCKER_HOST=" + h
+	}
+	if c := env.getenv("DOCKER_CONTEXT"); c != "" {
+		return c, "DOCKER_CONTEXT"
+	}
+
+	dir := env.DockerConfigDir
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "default", "implicit default"
+		}
+		dir = filepath.Join(home, ".docker")
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		return "default", "implicit default"
+	}
+	var cfg struct {
+		CurrentContext string `json:"currentContext"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil || cfg.CurrentContext == "" {
+		return "default", "implicit default"
+	}
+	return cfg.CurrentContext, "docker config.json"
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,145 @@
+package version
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// Report is the full component picture `hawser version` prints.
+type Report struct {
+	// App is Hawser's own version, stamped at build time.
+	App string `json:"app"`
+	// Engine describes the installed engine, from the install manifest.
+	Engine EngineInfo `json:"engine"`
+	// WSL is the host's WSL release, empty when it cannot be determined.
+	WSL string `json:"wsl,omitempty"`
+	// Docker lists every docker.exe on PATH, in resolution order.
+	Docker []Binary `json:"docker"`
+	// Context is the active docker context; empty when DOCKER_HOST overrides.
+	Context string `json:"context"`
+	// ContextSource says how Context was selected, which is half the answer
+	// when someone's shell disagrees with their config.
+	ContextSource string `json:"contextSource"`
+	// APIVersion is the negotiated engine API version, when the engine
+	// answered. Empty means it was not reachable, not that it is unknown.
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Warnings flags conditions that make the setup behave unexpectedly.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// EngineInfo is what the install manifest recorded.
+type EngineInfo struct {
+	Installed bool   `json:"installed"`
+	Version   string `json:"version,omitempty"`
+	Distro    string `json:"distro,omitempty"`
+	Rootfs    string `json:"rootfsSha256,omitempty"`
+	// WSLAtInstall is the WSL version present when Hawser was installed;
+	// a difference from WSL means the host was updated since.
+	WSLAtInstall string `json:"wslAtInstall,omitempty"`
+}
+
+// analyze fills in Warnings from the collected facts. Kept separate so the
+// rules are testable without touching a filesystem.
+func (r *Report) analyze() {
+	first := r.firstDocker()
+
+	// PATH shadowing: the hawser context is selected, but a foreign docker.exe
+	// runs first. Commands still work — that binary talks to whatever its
+	// context says — but the user is not driving Hawser, which looks like a
+	// Hawser fault (PLAN §05, v0.3 doctor check).
+	if r.Context == "hawser" && first != nil && first.Origin != OriginHawser {
+		r.Warnings = append(r.Warnings, fmt.Sprintf(
+			"the hawser context is active but %s (%s) resolves first on PATH; "+
+				"put Hawser's bin directory earlier, or use its full path",
+			first.Path, first.Origin))
+	}
+
+	if len(r.Docker) == 0 {
+		r.Warnings = append(r.Warnings,
+			"no docker.exe found on PATH; install Hawser's bundled CLI or add it to PATH")
+	}
+
+	if r.Engine.Installed && r.Engine.WSLAtInstall != "" && r.WSL != "" &&
+		r.Engine.WSLAtInstall != r.WSL {
+		r.Warnings = append(r.Warnings, fmt.Sprintf(
+			"WSL was %s when Hawser was installed and is %s now; "+
+				"run `hawser doctor` if the engine misbehaves",
+			r.Engine.WSLAtInstall, r.WSL))
+	}
+
+	if !r.Engine.Installed {
+		r.Warnings = append(r.Warnings, "no engine installed; run `hawser install`")
+	}
+}
+
+func (r *Report) firstDocker() *Binary {
+	for i := range r.Docker {
+		if r.Docker[i].First {
+			return &r.Docker[i]
+		}
+	}
+	return nil
+}
+
+// WriteText renders the report for a terminal.
+func (r *Report) WriteText(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "hawser\t%s\n", r.App)
+	if r.Engine.Installed {
+		fmt.Fprintf(tw, "engine\t%s\t(distro %s)\n", orUnknown(r.Engine.Version), r.Engine.Distro)
+		if r.Engine.Rootfs != "" {
+			fmt.Fprintf(tw, "rootfs\t%s\n", shortSHA(r.Engine.Rootfs))
+		}
+	} else {
+		fmt.Fprintf(tw, "engine\tnot installed\n")
+	}
+	fmt.Fprintf(tw, "wsl\t%s\n", orUnknown(r.WSL))
+
+	if r.Context != "" {
+		fmt.Fprintf(tw, "context\t%s\t(%s)\n", r.Context, r.ContextSource)
+	} else {
+		fmt.Fprintf(tw, "context\t-\t(%s)\n", r.ContextSource)
+	}
+	if r.APIVersion != "" {
+		fmt.Fprintf(tw, "api\t%s\n", r.APIVersion)
+	}
+
+	if len(r.Docker) == 0 {
+		fmt.Fprintf(tw, "docker\tnone found on PATH\n")
+	}
+	for _, b := range r.Docker {
+		marker := " "
+		if b.First {
+			marker = "*"
+		}
+		fmt.Fprintf(tw, "docker %s\t%s\t%s\n", marker, b.Origin, b.Path)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(r.Docker) > 1 {
+		fmt.Fprintln(w, "\n(* is the one that runs when you type `docker`)")
+	}
+	for _, warn := range r.Warnings {
+		fmt.Fprintf(w, "\nwarning: %s\n", warn)
+	}
+	return nil
+}
+
+func orUnknown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "unknown"
+	}
+	return s
+}
+
+func shortSHA(s string) string {
+	if len(s) > 12 {
+		return s[:12] + "..."
+	}
+	return s
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,374 @@
+package version_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/version"
+)
+
+// fakeFS answers Stat from a set of paths, so PATH scanning needs no real files.
+func fakeFS(present ...string) func(string) error {
+	set := map[string]bool{}
+	for _, p := range present {
+		set[strings.ToLower(filepath.Clean(p))] = true
+	}
+	return func(p string) error {
+		if set[strings.ToLower(filepath.Clean(p))] {
+			return nil
+		}
+		return os.ErrNotExist
+	}
+}
+
+func envWith(pathDirs []string, present []string, hawserBin string) version.Env {
+	return version.Env{
+		PathVar:   strings.Join(pathDirs, string(os.PathListSeparator)),
+		PathExt:   ".EXE",
+		HawserBin: hawserBin,
+		Stat:      fakeFS(present...),
+		Getenv:    func(string) string { return "" },
+	}
+}
+
+func TestFindDockerBinariesResolutionOrder(t *testing.T) {
+	// The first match on PATH is the one that runs; everything else is context.
+	dirs := []string{
+		`C:\Program Files\Docker\Docker\resources\bin`,
+		`C:\Users\me\AppData\Local\Hawser\bin`,
+		`C:\ProgramData\chocolatey\bin`,
+	}
+	present := []string{
+		`C:\Program Files\Docker\Docker\resources\bin\docker.exe`,
+		`C:\Users\me\AppData\Local\Hawser\bin\docker.exe`,
+		`C:\ProgramData\chocolatey\bin\docker.exe`,
+	}
+	got := version.FindDockerBinaries(envWith(dirs, present, `C:\Users\me\AppData\Local\Hawser\bin`))
+
+	if len(got) != 3 {
+		t.Fatalf("found %d binaries %+v, want 3", len(got), got)
+	}
+	if !got[0].First {
+		t.Error("first entry is not marked First")
+	}
+	if got[1].First || got[2].First {
+		t.Error("more than one entry marked First")
+	}
+	want := []version.Origin{
+		version.OriginDockerDesktop, version.OriginHawser, version.OriginChocolatey,
+	}
+	for i, w := range want {
+		if got[i].Origin != w {
+			t.Errorf("binary %d origin = %q, want %q (%s)", i, got[i].Origin, w, got[i].Path)
+		}
+	}
+}
+
+func TestClassifyOrigins(t *testing.T) {
+	hawserBin := `C:\Tools\Hawser\bin`
+	tests := []struct {
+		path string
+		want version.Origin
+	}{
+		{`C:\Tools\Hawser\bin\docker.exe`, version.OriginHawser},
+		{`C:\Program Files\Docker\Docker\resources\bin\docker.exe`, version.OriginDockerDesktop},
+		{`C:\Users\me\AppData\Local\Programs\rancher-desktop\resources\bin\docker.exe`, version.OriginRancher},
+		{`C:\Users\me\AppData\Local\Microsoft\WinGet\Links\docker.exe`, version.OriginWinget},
+		{`C:\ProgramData\chocolatey\bin\docker.exe`, version.OriginChocolatey},
+		{`C:\Users\me\scoop\shims\docker.exe`, version.OriginScoop},
+		{`D:\somewhere\odd\docker.exe`, version.OriginUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.want), func(t *testing.T) {
+			got := version.FindDockerBinaries(envWith(
+				[]string{filepath.Dir(tt.path)}, []string{tt.path}, hawserBin))
+			if len(got) != 1 {
+				t.Fatalf("found %d, want 1", len(got))
+			}
+			if got[0].Origin != tt.want {
+				t.Errorf("origin = %q, want %q", got[0].Origin, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindDockerBinariesDeduplicates(t *testing.T) {
+	// A directory listed twice in PATH must not produce two entries.
+	dir := `C:\bin`
+	env := envWith([]string{dir, dir}, []string{dir + `\docker.exe`}, "")
+	if got := version.FindDockerBinaries(env); len(got) != 1 {
+		t.Errorf("found %d binaries, want 1: %+v", len(got), got)
+	}
+}
+
+func TestFindDockerBinariesOneEntryPerDirectory(t *testing.T) {
+	// Docker Desktop ships both docker.exe and an extensionless docker in the
+	// same directory. PATH resolves one file per directory, so reporting two
+	// would dress noise up as a second installation. Found by running
+	// `hawser version` on a machine with Docker Desktop installed.
+	dir := `C:\Program Files\Docker\Docker\resources\bin`
+	env := envWith([]string{dir}, []string{dir + `\docker.exe`, dir + `\docker`}, "")
+
+	got := version.FindDockerBinaries(env)
+	if len(got) != 1 {
+		t.Fatalf("found %d binaries, want 1: %+v", len(got), got)
+	}
+	// The .exe is what Windows actually runs, so that is what gets reported.
+	if !strings.HasSuffix(got[0].Path, ".exe") {
+		t.Errorf("reported %q, want the .exe", got[0].Path)
+	}
+}
+
+func TestFindDockerBinariesNone(t *testing.T) {
+	env := envWith([]string{`C:\empty`}, nil, "")
+	if got := version.FindDockerBinaries(env); len(got) != 0 {
+		t.Errorf("found %+v, want none", got)
+	}
+}
+
+func TestDockerContextPrecedence(t *testing.T) {
+	// DOCKER_HOST wins and means no context is in play; then DOCKER_CONTEXT;
+	// then config.json. This mirrors the docker CLI, and getting the order
+	// wrong would make the report actively misleading.
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfg, []byte(`{"currentContext":"from-config"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := version.Env{DockerConfigDir: dir, Stat: fakeFS()}
+
+	t.Run("DOCKER_HOST overrides", func(t *testing.T) {
+		e := base
+		e.Getenv = func(k string) string {
+			if k == "DOCKER_HOST" {
+				return "npipe:////./pipe/hawser_engine"
+			}
+			return ""
+		}
+		name, src := version.DockerContext(e)
+		if name != "" {
+			t.Errorf("context = %q, want empty when DOCKER_HOST is set", name)
+		}
+		if !strings.Contains(src, "DOCKER_HOST") {
+			t.Errorf("source = %q, should name DOCKER_HOST", src)
+		}
+	})
+
+	t.Run("DOCKER_CONTEXT beats config", func(t *testing.T) {
+		e := base
+		e.Getenv = func(k string) string {
+			if k == "DOCKER_CONTEXT" {
+				return "from-env"
+			}
+			return ""
+		}
+		name, src := version.DockerContext(e)
+		if name != "from-env" || src != "DOCKER_CONTEXT" {
+			t.Errorf("got (%q, %q), want (from-env, DOCKER_CONTEXT)", name, src)
+		}
+	})
+
+	t.Run("config.json", func(t *testing.T) {
+		e := base
+		e.Getenv = func(string) string { return "" }
+		name, src := version.DockerContext(e)
+		if name != "from-config" {
+			t.Errorf("context = %q, want from-config", name)
+		}
+		if !strings.Contains(src, "config.json") {
+			t.Errorf("source = %q, should name config.json", src)
+		}
+	})
+
+	t.Run("no config falls back to default", func(t *testing.T) {
+		e := version.Env{
+			DockerConfigDir: filepath.Join(dir, "nonexistent"),
+			Getenv:          func(string) string { return "" },
+		}
+		name, _ := version.DockerContext(e)
+		if name != "default" {
+			t.Errorf("context = %q, want default", name)
+		}
+	})
+
+	t.Run("malformed config falls back to default", func(t *testing.T) {
+		bad := t.TempDir()
+		if err := os.WriteFile(filepath.Join(bad, "config.json"), []byte("{not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		e := version.Env{DockerConfigDir: bad, Getenv: func(string) string { return "" }}
+		if name, _ := version.DockerContext(e); name != "default" {
+			t.Errorf("context = %q, want default", name)
+		}
+	})
+}
+
+func TestWarnsOnPathShadowing(t *testing.T) {
+	// The headline diagnostic: the hawser context is active but Docker
+	// Desktop's binary runs first. Commands succeed while doing something the
+	// user did not intend, which is why this needs saying out loud.
+	dirs := []string{`C:\Program Files\Docker\Docker\resources\bin`, `C:\Hawser\bin`}
+	present := []string{
+		`C:\Program Files\Docker\Docker\resources\bin\docker.exe`,
+		`C:\Hawser\bin\docker.exe`,
+	}
+	env := envWith(dirs, present, `C:\Hawser\bin`)
+	env.Getenv = func(k string) string {
+		if k == "DOCKER_CONTEXT" {
+			return "hawser"
+		}
+		return ""
+	}
+
+	c := &version.Collector{App: "1.2.3", Env: env}
+	r := c.Collect(context.Background())
+
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "resolves first on PATH") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %+v, want one about PATH shadowing", r.Warnings)
+	}
+}
+
+func TestNoShadowingWarningWhenHawserIsFirst(t *testing.T) {
+	dirs := []string{`C:\Hawser\bin`, `C:\Program Files\Docker\Docker\resources\bin`}
+	present := []string{
+		`C:\Hawser\bin\docker.exe`,
+		`C:\Program Files\Docker\Docker\resources\bin\docker.exe`,
+	}
+	env := envWith(dirs, present, `C:\Hawser\bin`)
+	env.Getenv = func(k string) string {
+		if k == "DOCKER_CONTEXT" {
+			return "hawser"
+		}
+		return ""
+	}
+
+	r := (&version.Collector{App: "1.2.3", Env: env}).Collect(context.Background())
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "resolves first on PATH") {
+			t.Errorf("unexpected shadowing warning: %s", w)
+		}
+	}
+}
+
+func TestWarnsWhenNoDockerFound(t *testing.T) {
+	env := envWith([]string{`C:\empty`}, nil, "")
+	r := (&version.Collector{App: "1.2.3", Env: env}).Collect(context.Background())
+
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "no docker.exe") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %+v, want one about a missing docker.exe", r.Warnings)
+	}
+}
+
+func TestWarnsWhenNoEngineInstalled(t *testing.T) {
+	env := envWith([]string{`C:\bin`}, []string{`C:\bin\docker.exe`}, "")
+	r := (&version.Collector{App: "1.2.3", Env: env}).Collect(context.Background())
+	if r.Engine.Installed {
+		t.Fatal("Engine.Installed true with no manifest")
+	}
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "hawser install") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %+v, want one suggesting hawser install", r.Warnings)
+	}
+}
+
+func TestAPIProbeIsBestEffort(t *testing.T) {
+	// `hawser version` is what someone runs when things are broken, so an
+	// unreachable engine must not fail the command.
+	env := envWith([]string{`C:\bin`}, []string{`C:\bin\docker.exe`}, "")
+
+	failing := &version.Collector{App: "1.0.0", Env: env,
+		ProbeAPI: func(context.Context) (string, error) {
+			return "", errors.New("engine not reachable")
+		}}
+	if r := failing.Collect(context.Background()); r.APIVersion != "" {
+		t.Errorf("APIVersion = %q, want empty when the probe fails", r.APIVersion)
+	}
+
+	ok := &version.Collector{App: "1.0.0", Env: env,
+		ProbeAPI: func(context.Context) (string, error) { return "1.55", nil }}
+	if r := ok.Collect(context.Background()); r.APIVersion != "1.55" {
+		t.Errorf("APIVersion = %q, want 1.55", r.APIVersion)
+	}
+}
+
+func TestJSONIsStableForScripts(t *testing.T) {
+	// CI scripts assert on this, so the field names are a contract.
+	env := envWith([]string{`C:\bin`}, []string{`C:\bin\docker.exe`}, `C:\bin`)
+	r := (&version.Collector{App: "1.2.3", Env: env}).Collect(context.Background())
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(b, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"app", "engine", "docker", "context", "contextSource"} {
+		if _, ok := generic[key]; !ok {
+			t.Errorf("JSON is missing the %q field: %s", key, b)
+		}
+	}
+	engine := generic["engine"].(map[string]any)
+	if _, ok := engine["installed"]; !ok {
+		t.Errorf("engine object is missing %q", "installed")
+	}
+}
+
+func TestWriteTextIncludesTheDecisiveFacts(t *testing.T) {
+	dirs := []string{`C:\Program Files\Docker\Docker\resources\bin`, `C:\Hawser\bin`}
+	present := []string{
+		`C:\Program Files\Docker\Docker\resources\bin\docker.exe`,
+		`C:\Hawser\bin\docker.exe`,
+	}
+	env := envWith(dirs, present, `C:\Hawser\bin`)
+	env.Getenv = func(k string) string {
+		if k == "DOCKER_CONTEXT" {
+			return "hawser"
+		}
+		return ""
+	}
+	r := (&version.Collector{App: "1.2.3", Env: env}).Collect(context.Background())
+
+	var sb strings.Builder
+	if err := r.WriteText(&sb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := sb.String()
+
+	for _, want := range []string{
+		"1.2.3",             // app version
+		"hawser",            // context
+		"docker-desktop",    // the competing binary is named
+		`C:\Hawser\bin`,     // and so is ours
+		"resolves first",    // the shadowing warning
+		"the one that runs", // the legend explaining the marker
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #10. Also turns `cmd/hawser` from a stub into an actual CLI — this is the first command that runs.

**The substance is PATH resolution, not Hawser''s own version.** A machine that has hosted Docker Desktop, Rancher Desktop, winget and Hawser can easily have four `docker.exe` files, and a foreign one resolving first while the `hawser` context is active produces symptoms that look exactly like Hawser being broken. So the report names every docker on PATH **in resolution order**, attributes each to its owner by install location, marks the one that actually runs, and warns explicitly on that mismatch.

Verified against this machine (Docker Desktop + Rancher Desktop installed):

```
hawser    dev
engine    not installed
wsl       2.7.8.0
context   hawser          (DOCKER_CONTEXT)
docker *  docker-desktop  C:\Program Files\Docker\Docker\resources\bin\docker.exe

warning: the hawser context is active but C:\Program Files\...\docker.exe
         (docker-desktop) resolves first on PATH; put Hawser''s bin
         directory earlier, or use its full path
```

**Decisions worth review:**
- **Context precedence mirrors the docker CLI** — `DOCKER_HOST`, then `DOCKER_CONTEXT`, then `config.json`, then implicit default — and the report says *which source won*. That''s half the answer whenever someone''s shell disagrees with their config.
- **Degrades gracefully.** `hawser version` is the first thing anyone runs when things are broken, so a missing manifest, unreachable engine or absent WSL yields "unknown" rather than a failure. The API-version probe is best-effort by design, with a test asserting a failing probe doesn''t fail the command.
- **Exit code 3 means "nothing installed"**, so a provisioning script can branch on installed-ness without parsing output. Codes are part of the CLI contract (PLAN §03).
- **Only implemented commands are listed** in usage. No stubs that lie about what exists.
- Renamed the build stamp to `buildVersion` — the old `version` collided with the imported `version` package. Release ldflags become `-X main.buildVersion=...`.

**Running it for real found a bug the unit tests didn''t.** Docker Desktop ships both `docker.exe` and an extensionless `docker` in the same directory, and both were being reported as separate installations. PATH resolves one file per directory, so discovery now stops at the first match per directory — kept as a regression test, with the provenance noted in the comment.

14 tests in the package; 89 → 103 overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)