### PR TITLE
hawser install / uninstall, and the locked release manifest

### DIFF
--- a/cmd/hawser/console.go
+++ b/cmd/hawser/console.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+// consoleHandler renders slog records as short human lines.
+//
+// The default text handler emits logfmt, which is right for a service and wrong
+// for someone watching an install: "time=... level=INFO msg=importing distro
+// distro=hawser-engine" buries the sentence in metadata. This prints the
+// message, then only the attributes that add something.
+type consoleHandler struct {
+	mu    *sync.Mutex
+	w     io.Writer
+	level slog.Level
+}
+
+func newConsoleHandler(w io.Writer, level slog.Level) slog.Handler {
+	return &consoleHandler{mu: &sync.Mutex{}, w: w, level: level}
+}
+
+func (h *consoleHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level
+}
+
+func (h *consoleHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+
+	switch {
+	case r.Level >= slog.LevelError:
+		b.WriteString("error: ")
+	case r.Level >= slog.LevelWarn:
+		b.WriteString("warning: ")
+	default:
+		b.WriteString("  ")
+	}
+	b.WriteString(r.Message)
+
+	r.Attrs(func(a slog.Attr) bool {
+		// "fix" carries a remedy, which belongs on its own line where it can
+		// be read rather than appended to a key=value tail.
+		if a.Key == "fix" {
+			return true
+		}
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+		return true
+	})
+	b.WriteString("\n")
+
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "fix" {
+			fmt.Fprintf(&b, "    fix: %v\n", a.Value)
+		}
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, b.String())
+	return err
+}
+
+func (h *consoleHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *consoleHandler) WithGroup(string) slog.Handler      { return h }
+
+// emitJSON writes v to stdout for scripting, and is the only place --json
+// output is produced so the shape stays consistent across commands.
+func emitJSON(v any) int {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	return exitOK
+}

--- a/cmd/hawser/install.go
+++ b/cmd/hawser/install.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/release"
+)
+
+// cliLogger prints progress as plain lines rather than structured logfmt: this
+// is a person watching an install, not a log aggregator.
+func cliLogger(quiet bool) *slog.Logger {
+	level := slog.LevelInfo
+	if quiet {
+		level = slog.LevelWarn
+	}
+	return slog.New(newConsoleHandler(os.Stderr, level))
+}
+
+// interruptible returns a context cancelled on Ctrl-C, so a long download stops
+// promptly and leaves no partial file behind (the provisioner handles cleanup).
+func interruptible() (context.Context, func()) {
+	return signal.NotifyContext(context.Background(), os.Interrupt)
+}
+
+func runInstall(args []string) int {
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	var (
+		engineVersion = fs.String("engine-version", "", "engine version to install (default: this build's default)")
+		distro        = fs.String("distro", "", "WSL distro name (default: "+provision.DefaultDistro+")")
+		dataDir       = fs.String("data-dir", "", "where the distro's VHDX lives (default: under the state dir)")
+		stateDir      = fs.String("state-dir", "", "override Hawser's state directory")
+		headless      = fs.Bool("headless", false, "never prompt; for unattended and CI installs")
+		rootfsURL     = fs.String("rootfs-url", "", "override the rootfs URL (development)")
+		rootfsSHA     = fs.String("rootfs-sha256", "", "expected rootfs SHA-256; required with --rootfs-url")
+		asJSON        = fs.Bool("json", false, "emit the resulting manifest as JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser install [flags]
+
+Provisions the Hawser engine distro: checks the host, downloads and verifies the
+rootfs, imports it as a WSL2 distro, and starts the engine.
+
+The rootfs is always checksum-verified. Version pinning is a contract: this
+build installs exactly the components in its embedded manifest, and nothing is
+fetched as "latest".
+
+Exit codes: 0 ok, %d error, %d usage.
+
+flags:
+`, exitError, exitUsage)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	log := cliLogger(*asJSON)
+
+	opts := provision.Options{
+		Distro:   *distro,
+		StateDir: *stateDir,
+		DataDir:  *dataDir,
+		Headless: *headless,
+	}
+
+	// An explicit URL bypasses the manifest, so it must carry its own digest:
+	// there is no code path that imports an unverified rootfs.
+	switch {
+	case *rootfsURL != "" && *rootfsSHA == "":
+		fmt.Fprintln(os.Stderr, "hawser: --rootfs-url requires --rootfs-sha256")
+		return exitUsage
+	case *rootfsURL != "":
+		opts.RootfsURL = *rootfsURL
+		opts.RootfsSHA256 = *rootfsSHA
+		opts.EngineVersion = *engineVersion
+		log.Warn("using an overridden rootfs; this is a development path, not a release install",
+			"url", *rootfsURL)
+	default:
+		m, err := release.Load()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		engine, err := m.Engine(*engineVersion)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitUsage
+		}
+		if !engine.Published() {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", &release.ErrNotPublished{Version: engine.Version})
+			return exitError
+		}
+		opts.RootfsURL = engine.Rootfs.URL
+		opts.RootfsSHA256 = engine.Rootfs.SHA256
+		opts.EngineVersion = engine.Version
+	}
+
+	ctx, stop := interruptible()
+	defer stop()
+
+	p := &provision.Provisioner{Logger: log}
+	manifest, err := p.Install(ctx, opts)
+	if err != nil {
+		// A preflight failure is the user's to act on, and its remedies are
+		// already formatted; anything else is reported plainly.
+		var pfe *provision.PreflightError
+		if errors.As(err, &pfe) {
+			fmt.Fprint(os.Stderr, "hawser: cannot install yet.\n\n")
+			for _, p := range pfe.Report.Problems {
+				fmt.Fprintf(os.Stderr, "  %s\n    fix: %s\n\n", p.Summary, p.Remedy)
+			}
+			return exitError
+		}
+		fmt.Fprintf(os.Stderr, "hawser: install failed: %v\n", err)
+		return exitError
+	}
+
+	if *asJSON {
+		return emitJSON(manifest)
+	}
+
+	fmt.Printf(`
+Engine installed and running.
+
+  distro   %s
+  engine   %s
+  data     %s
+
+Next: point your docker client at it.
+
+  $env:DOCKER_HOST = "npipe:////./pipe/hawser_engine"
+  docker run --rm hello-world
+
+A `+"`hawser` docker context and a bundled docker CLI are coming in #9;\nuntil then DOCKER_HOST is the way in.\n",
+		manifest.Distro, manifest.EngineVersion, manifest.DataDir)
+	return exitOK
+}
+
+func runUninstall(args []string) int {
+	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	var (
+		distro   = fs.String("distro", "", "WSL distro name (default: from the install manifest)")
+		stateDir = fs.String("state-dir", "", "override Hawser's state directory")
+		yes      = fs.Bool("yes", false, "skip the confirmation prompt")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser uninstall [--yes]
+
+Unregisters the engine distro and removes Hawser's own state. Nothing else on
+the system is touched.
+
+This DELETES the distro, and with it every image, container and volume it
+holds. Export anything you want to keep first.
+
+Exit codes: 0 ok, %d error.
+
+flags:
+`, exitError)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := provision.Options{Distro: *distro, StateDir: *stateDir}
+	log := cliLogger(false)
+	p := &provision.Provisioner{Logger: log}
+
+	// Say what will actually be destroyed, using the recorded manifest rather
+	// than a guess, before asking.
+	target := opts.Distro
+	if m, err := p.ReadManifest(opts); err == nil && m.Distro != "" {
+		target = m.Distro
+	} else if target == "" {
+		target = provision.DefaultDistro
+	}
+
+	if !*yes {
+		fmt.Printf("This will unregister the WSL distro %q and delete all images, "+
+			"containers and volumes in it.\nThis cannot be undone. Continue? [y/N] ", target)
+		var answer string
+		fmt.Scanln(&answer)
+		if answer != "y" && answer != "Y" {
+			fmt.Println("aborted")
+			return exitOK
+		}
+	}
+
+	ctx, stop := interruptible()
+	defer stop()
+
+	if err := p.Uninstall(ctx, opts); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	fmt.Println("Removed. Nothing else on the system was modified.")
+	return exitOK
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -27,6 +27,8 @@ type command struct {
 
 func commands() []command {
 	return []command{
+		{"install", "provision the engine distro and start it", runInstall},
+		{"uninstall", "remove the engine distro and Hawser's state", runUninstall},
 		{"version", "report every component version and which docker.exe is active", runVersion},
 	}
 }

--- a/internal/provision/download.go
+++ b/internal/provision/download.go
@@ -19,11 +19,25 @@ type Fetcher interface {
 	Fetch(ctx context.Context, url string) (io.ReadCloser, error)
 }
 
-// HTTPFetcher retrieves over HTTP(S) using the given client.
+// HTTPFetcher retrieves a rootfs over HTTP(S), or from the local filesystem for
+// a file:// URL or a plain path.
+//
+// Local paths are supported because a development install and the acceptance
+// suite both need to install a rootfs built by guest/rootfs/build.sh before any
+// release exists — which is exactly what ErrNotPublished tells the user to do.
+// Verification is identical either way: a local rootfs is checksummed too.
 type HTTPFetcher struct{ Client *http.Client }
 
 // Fetch implements Fetcher.
 func (f HTTPFetcher) Fetch(ctx context.Context, url string) (io.ReadCloser, error) {
+	if path, ok := localPath(url); ok {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("opening local rootfs %s: %w", path, err)
+		}
+		return file, nil
+	}
+
 	client := f.Client
 	if client == nil {
 		client = http.DefaultClient
@@ -41,6 +55,30 @@ func (f HTTPFetcher) Fetch(ctx context.Context, url string) (io.ReadCloser, erro
 		return nil, fmt.Errorf("fetching %s: HTTP %s", url, resp.Status)
 	}
 	return resp.Body, nil
+}
+
+// localPath recognizes a filesystem source and returns the path to open.
+//
+// Handles file:// URLs (including Windows' file:///C:/x and file://C:/x spellings)
+// and bare paths such as C:\build\rootfs.tar.gz — which is what someone
+// naturally passes to --rootfs-url after running the rootfs build.
+func localPath(raw string) (string, bool) {
+	if after, ok := strings.CutPrefix(raw, "file://"); ok {
+		// file:///C:/x -> /C:/x; strip the leading slash before a drive letter.
+		p := after
+		if len(p) > 2 && p[0] == '/' && p[2] == ':' {
+			p = p[1:]
+		}
+		return filepath.FromSlash(p), true
+	}
+	// A Windows drive path is not a URL scheme, despite the colon.
+	if len(raw) > 2 && raw[1] == ':' {
+		return filepath.FromSlash(raw), true
+	}
+	if strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, `\`) || strings.HasPrefix(raw, ".") {
+		return filepath.FromSlash(raw), true
+	}
+	return "", false
 }
 
 // ErrChecksumMismatch reports a rootfs whose contents do not match the expected

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/zcsizmadia/hawser/internal/wsl"
@@ -165,12 +166,20 @@ func (p *Provisioner) Install(ctx context.Context, opts Options) (*Manifest, err
 		return nil, fmt.Errorf("importing %s: %w", opts.Distro, err)
 	}
 
+	engineVersion := opts.EngineVersion
+	if engineVersion == "" {
+		// The rootfs records what it actually contains, which is more
+		// trustworthy than a flag and is the only source available when the
+		// rootfs came from --rootfs-url rather than the release manifest.
+		engineVersion = p.engineVersionFromDistro(ctx, opts)
+	}
+
 	m := &Manifest{
 		Distro:        opts.Distro,
 		DataDir:       opts.DataDir,
 		RootfsURL:     opts.RootfsURL,
 		RootfsSHA256:  opts.RootfsSHA256,
-		EngineVersion: opts.EngineVersion,
+		EngineVersion: engineVersion,
 		InstalledAt:   time.Now().UTC(),
 		WSLVersion:    report.Status.Version,
 	}
@@ -184,6 +193,22 @@ func (p *Provisioner) Install(ctx context.Context, opts Options) (*Manifest, err
 		return m, fmt.Errorf("starting engine: %w", err)
 	}
 	return m, nil
+}
+
+// EngineVersionFile is where the rootfs records the engine it carries.
+const EngineVersionFile = "/etc/hawser/engine-version"
+
+// engineVersionFromDistro reads the version the rootfs declares. Best-effort:
+// a rootfs without the marker is unusual but not a reason to fail an install,
+// and `hawser version` reports an unknown engine rather than a wrong one.
+func (p *Provisioner) engineVersionFromDistro(ctx context.Context, opts Options) string {
+	out, err := p.wsl().Exec(ctx, opts.Distro, "root", "cat", EngineVersionFile)
+	if err != nil {
+		p.logger().Debug("rootfs declares no engine version",
+			"file", EngineVersionFile, "error", err)
+		return ""
+	}
+	return strings.TrimSpace(out)
 }
 
 // StartEngine launches dockerd and waits for its socket.

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -38,6 +38,10 @@ type fakeWSL struct {
 	socketUpAfter int
 	socketCalls   int
 
+	// engineVersionFile is what /etc/hawser/engine-version contains; empty
+	// means the file is absent.
+	engineVersionFile string
+
 	importErr error
 	statusErr error
 	listErr   error
@@ -110,6 +114,12 @@ func (f *fakeWSL) Exec(_ context.Context, _, _ string, args ...string) (string, 
 	}
 	if len(args) > 0 && args[0] == "tail" {
 		return "dockerd log line 1\ndockerd log line 2", nil
+	}
+	if len(args) >= 2 && args[0] == "cat" && args[1] == provision.EngineVersionFile {
+		if f.engineVersionFile == "" {
+			return "", errors.New("cat: no such file")
+		}
+		return f.engineVersionFile, nil
 	}
 	return "", nil
 }
@@ -497,5 +507,126 @@ func TestFetcherSeam(t *testing.T) {
 
 	if _, err := p.Install(context.Background(), opts); err != nil {
 		t.Fatalf("Install: %v", err)
+	}
+}
+
+func TestInstallFromLocalRootfs(t *testing.T) {
+	// The path ErrNotPublished tells developers to use: install a rootfs built
+	// locally, before any release exists. Verification still applies.
+	payload := []byte("locally built rootfs")
+	dir := t.TempDir()
+	local := filepath.Join(dir, "hawser-rootfs-29.7.2.tar.gz")
+	if err := os.WriteFile(local, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := sha256.Sum256(payload)
+
+	w := healthyWSL()
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+
+	for _, spelling := range []string{
+		local,                                // bare Windows path
+		"file:///" + filepath.ToSlash(local), // file:///C:/...
+		"file://" + filepath.ToSlash(local),  // file://C:/...
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			w2 := healthyWSL()
+			p2 := &provision.Provisioner{WSL: w2, Logger: quietLogger()}
+			opts := testOptions(t, spelling, hex.EncodeToString(h[:]))
+			if _, err := p2.Install(context.Background(), opts); err != nil {
+				t.Fatalf("Install from %q: %v", spelling, err)
+			}
+			if len(w2.imported) != 1 {
+				t.Errorf("imported %d, want 1", len(w2.imported))
+			}
+		})
+	}
+	_ = p
+}
+
+func TestInstallLocalRootfsStillVerifiesChecksum(t *testing.T) {
+	// A local file is not more trusted than a downloaded one.
+	dir := t.TempDir()
+	local := filepath.Join(dir, "rootfs.tar.gz")
+	if err := os.WriteFile(local, []byte("contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, local, strings.Repeat("b", 64))
+
+	var mismatch *provision.ErrChecksumMismatch
+	if _, err := p.Install(context.Background(), opts); !errors.As(err, &mismatch) {
+		t.Fatalf("error = %v, want ErrChecksumMismatch", err)
+	}
+}
+
+func TestInstallMissingLocalRootfsIsClear(t *testing.T) {
+	p := &provision.Provisioner{WSL: healthyWSL(), Logger: quietLogger()}
+	opts := testOptions(t, filepath.Join(t.TempDir(), "absent.tar.gz"), strings.Repeat("c", 64))
+
+	_, err := p.Install(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Install succeeded with a missing local rootfs")
+	}
+	if !strings.Contains(err.Error(), "local rootfs") {
+		t.Errorf("error should say the local rootfs could not be opened, got: %v", err)
+	}
+}
+
+func TestInstallReadsEngineVersionFromRootfs(t *testing.T) {
+	// With --rootfs-url and no --engine-version there is no flag to trust, so
+	// the rootfs's own /etc/hawser/engine-version is the source of truth.
+	// Without this, `hawser version` reports "engine unknown" after a
+	// development install - seen for real before this was added.
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	w.engineVersionFile = "29.7.2\n"
+
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum)
+	opts.EngineVersion = "" // as an override install leaves it
+
+	m, err := p.Install(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m.EngineVersion != "29.7.2" {
+		t.Errorf("EngineVersion = %q, want 29.7.2 from the rootfs", m.EngineVersion)
+	}
+}
+
+func TestInstallPrefersExplicitEngineVersion(t *testing.T) {
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL()
+	w.engineVersionFile = "1.2.3\n"
+
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum) // testOptions sets 29.7.2
+
+	m, err := p.Install(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m.EngineVersion != "29.7.2" {
+		t.Errorf("EngineVersion = %q, want the explicit 29.7.2", m.EngineVersion)
+	}
+}
+
+func TestInstallToleratesRootfsWithoutVersionMarker(t *testing.T) {
+	// An old or third-party rootfs need not carry the marker; that is not a
+	// reason to fail an install.
+	url, sum := rootfsServer(t, []byte("rootfs"))
+	w := healthyWSL() // engineVersionFile empty -> cat fails
+	p := &provision.Provisioner{WSL: w, Logger: quietLogger()}
+	opts := testOptions(t, url, sum)
+	opts.EngineVersion = ""
+
+	m, err := p.Install(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m.EngineVersion != "" {
+		t.Errorf("EngineVersion = %q, want empty", m.EngineVersion)
 	}
 }

--- a/internal/release/manifest.json
+++ b/internal/release/manifest.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "comment": [
+    "The locked version manifest (PLAN section 04). Nothing is fetched as",
+    "'latest at install time': this file is compiled into the binary, so a",
+    "given Hawser build always installs exactly these components.",
+    "",
+    "rootfs.sha256 is filled in when a rootfs release is published. While it is",
+    "empty, `hawser install` refuses and tells the user to pass --rootfs-url and",
+    "--rootfs-sha256 explicitly, rather than silently installing something",
+    "unverified. Keep these values in step with guest/rootfs/versions.env."
+  ],
+  "engines": [
+    {
+      "version": "29.7.2",
+      "default": true,
+      "rootfs": {
+        "url": "https://github.com/zcsizmadia/hawser/releases/download/rootfs-v29.7.2/hawser-rootfs-29.7.2.tar.gz",
+        "sha256": ""
+      },
+      "components": {
+        "dockerd": "29.7.2",
+        "containerd": "2.1.4",
+        "runc": "1.3.0",
+        "buildkit": "0.27.0",
+        "alpine": "3.24.1"
+      }
+    }
+  ]
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,110 @@
+// Package release exposes the locked version manifest compiled into the binary.
+//
+// PLAN §04: nothing is fetched as "latest at install time". The manifest ships
+// inside the executable, so a given Hawser build installs exactly the
+// components it was tested with, and `hawser install` on a CI runner in six
+// months produces the same engine it produces today. That determinism is a
+// direct anti-feature of Docker Desktop's auto-updating, and the reason the
+// manifest is embedded rather than downloaded.
+package release
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+//go:embed manifest.json
+var manifestJSON []byte
+
+// Manifest is the set of engines a build can install.
+type Manifest struct {
+	SchemaVersion int      `json:"schemaVersion"`
+	Engines       []Engine `json:"engines"`
+}
+
+// Engine is one installable engine version and the rootfs that carries it.
+type Engine struct {
+	Version    string            `json:"version"`
+	Default    bool              `json:"default"`
+	Rootfs     Rootfs            `json:"rootfs"`
+	Components map[string]string `json:"components"`
+}
+
+// Rootfs locates a rootfs tarball and the digest it must match.
+type Rootfs struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+}
+
+// Published reports whether this entry can actually be installed. An entry
+// with no checksum is a placeholder: the rootfs release has not been cut yet,
+// and installing it unverified is not an option (the rootfs becomes root inside
+// the engine VM).
+func (e Engine) Published() bool {
+	return e.Rootfs.URL != "" && e.Rootfs.SHA256 != ""
+}
+
+// ErrNotPublished reports an engine entry without a checksum.
+type ErrNotPublished struct{ Version string }
+
+func (e *ErrNotPublished) Error() string {
+	return fmt.Sprintf("engine %s has no published rootfs checksum in this build's manifest.\n"+
+		"This happens in a development build before the rootfs release is cut. Either:\n"+
+		"  - install a release build of hawser, or\n"+
+		"  - build the rootfs yourself (guest/rootfs/build.sh) and pass\n"+
+		"    --rootfs-url file:///... together with --rootfs-sha256 <digest>",
+		e.Version)
+}
+
+// Load parses the embedded manifest.
+func Load() (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(manifestJSON, &m); err != nil {
+		return nil, fmt.Errorf("parsing embedded release manifest: %w", err)
+	}
+	if m.SchemaVersion != 1 {
+		// A future binary reading an older embedded file cannot happen, but a
+		// hand-edited manifest can, and silently misreading it would be worse.
+		return nil, fmt.Errorf("unsupported manifest schemaVersion %d", m.SchemaVersion)
+	}
+	if len(m.Engines) == 0 {
+		return nil, fmt.Errorf("release manifest lists no engines")
+	}
+	return &m, nil
+}
+
+// Engine returns the entry for a version, or the default when version is empty.
+//
+// Selection is exact: `--engine-version 29.7` does not resolve to 29.7.2,
+// because a pin that quietly matches something else is not a pin.
+func (m *Manifest) Engine(version string) (*Engine, error) {
+	if version == "" {
+		for i := range m.Engines {
+			if m.Engines[i].Default {
+				return &m.Engines[i], nil
+			}
+		}
+		return nil, fmt.Errorf("release manifest marks no default engine (available: %s)",
+			strings.Join(m.Versions(), ", "))
+	}
+	for i := range m.Engines {
+		if m.Engines[i].Version == version {
+			return &m.Engines[i], nil
+		}
+	}
+	return nil, fmt.Errorf("engine version %q is not in this build's manifest (available: %s)",
+		version, strings.Join(m.Versions(), ", "))
+}
+
+// Versions lists every engine version the build can install, sorted.
+func (m *Manifest) Versions() []string {
+	out := make([]string, 0, len(m.Engines))
+	for _, e := range m.Engines {
+		out = append(out, e.Version)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -1,0 +1,154 @@
+package release_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/release"
+)
+
+func TestEmbeddedManifestIsValid(t *testing.T) {
+	// The manifest is hand-edited alongside guest/rootfs/versions.env, so a
+	// typo must fail the build's tests rather than a user's install.
+	m, err := release.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(m.Engines) == 0 {
+		t.Fatal("no engines in the embedded manifest")
+	}
+
+	defaults := 0
+	for _, e := range m.Engines {
+		if e.Default {
+			defaults++
+		}
+		if e.Version == "" {
+			t.Error("an engine entry has no version")
+		}
+		if e.Rootfs.URL == "" {
+			t.Errorf("engine %s has no rootfs URL", e.Version)
+		}
+		// A digest, when present, must be a full SHA-256.
+		if e.Rootfs.SHA256 != "" && len(e.Rootfs.SHA256) != 64 {
+			t.Errorf("engine %s has a malformed sha256 (%d chars)", e.Version, len(e.Rootfs.SHA256))
+		}
+		for _, c := range []string{"dockerd", "containerd", "runc", "buildkit"} {
+			if e.Components[c] == "" {
+				t.Errorf("engine %s does not record the %s version", e.Version, c)
+			}
+		}
+	}
+	if defaults != 1 {
+		t.Errorf("%d engines marked default, want exactly 1", defaults)
+	}
+}
+
+func TestEmbeddedManifestMatchesRootfsPins(t *testing.T) {
+	// The manifest and the rootfs build must agree, or `hawser version` would
+	// report components the installed rootfs does not contain.
+	m, err := release.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e, err := m.Engine("")
+	if err != nil {
+		t.Fatalf("default engine: %v", err)
+	}
+
+	pins := readVersionsEnv(t)
+	if pins["ENGINE_VERSION"] != e.Version {
+		t.Errorf("manifest engine %s != versions.env ENGINE_VERSION %s",
+			e.Version, pins["ENGINE_VERSION"])
+	}
+	for envKey, component := range map[string]string{
+		"CONTAINERD_VERSION":    "containerd",
+		"RUNC_VERSION":          "runc",
+		"BUILDKIT_VERSION":      "buildkit",
+		"ALPINE_ROOTFS_VERSION": "alpine",
+	} {
+		want := strings.TrimPrefix(pins[envKey], "v")
+		if want == "" {
+			t.Fatalf("versions.env has no %s", envKey)
+		}
+		if got := e.Components[component]; got != want {
+			t.Errorf("manifest %s = %q, versions.env %s = %q", component, got, envKey, want)
+		}
+	}
+}
+
+func TestEngineSelectionIsExact(t *testing.T) {
+	// A pin that quietly resolves to something else is not a pin.
+	m, err := release.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def, err := m.Engine("")
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+
+	if _, err := m.Engine(def.Version); err != nil {
+		t.Errorf("exact version %q not found: %v", def.Version, err)
+	}
+
+	// A truncated prefix of a real version must not match it.
+	prefix := def.Version[:len(def.Version)-2]
+	if _, err := m.Engine(prefix); err == nil {
+		t.Errorf("prefix %q resolved to an engine; selection must be exact", prefix)
+	}
+}
+
+func TestEngineUnknownVersionListsChoices(t *testing.T) {
+	m, err := release.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = m.Engine("99.0.0")
+	if err == nil {
+		t.Fatal("unknown version succeeded")
+	}
+	// The error has to say what IS available, or the user is left guessing.
+	for _, v := range m.Versions() {
+		if !strings.Contains(err.Error(), v) {
+			t.Errorf("error %q does not list available version %q", err, v)
+		}
+	}
+}
+
+func TestPublishedRequiresBothURLAndChecksum(t *testing.T) {
+	cases := []struct {
+		name string
+		r    release.Rootfs
+		want bool
+	}{
+		{"both present", release.Rootfs{URL: "https://x/y.tar.gz", SHA256: strings.Repeat("a", 64)}, true},
+		{"no checksum", release.Rootfs{URL: "https://x/y.tar.gz"}, false},
+		{"no url", release.Rootfs{SHA256: strings.Repeat("a", 64)}, false},
+		{"neither", release.Rootfs{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := release.Engine{Version: "1.0.0", Rootfs: tc.r}
+			if got := e.Published(); got != tc.want {
+				t.Errorf("Published() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrNotPublishedExplainsTheWayOut(t *testing.T) {
+	// This is what a developer sees before the first release is cut, so it must
+	// name the escape hatch rather than just refusing.
+	err := error(&release.ErrNotPublished{Version: "29.7.2"})
+	for _, want := range []string{"29.7.2", "--rootfs-url", "--rootfs-sha256", "build.sh"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message should mention %q:\n%s", want, err)
+		}
+	}
+	var typed *release.ErrNotPublished
+	if !errors.As(err, &typed) {
+		t.Error("ErrNotPublished is not matchable with errors.As")
+	}
+}

--- a/internal/release/versions_env_test.go
+++ b/internal/release/versions_env_test.go
@@ -1,0 +1,62 @@
+package release_test
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readVersionsEnv parses guest/rootfs/versions.env so the embedded manifest can
+// be checked against the pins the rootfs is actually built from. Keeping the
+// two in step by hand is exactly the kind of thing that drifts silently.
+func readVersionsEnv(t *testing.T) map[string]string {
+	t.Helper()
+
+	// The test binary runs in the package directory; walk up to the repo root.
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	var path string
+	for i := 0; i < 5; i++ {
+		candidate := filepath.Join(dir, "guest", "rootfs", "versions.env")
+		if _, err := os.Stat(candidate); err == nil {
+			path = candidate
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+	if path == "" {
+		t.Skip("guest/rootfs/versions.env not found; skipping cross-check")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("opening %s: %v", path, err)
+	}
+	defer f.Close()
+
+	out := map[string]string{}
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		// Strip a trailing comment, then quotes.
+		if i := strings.Index(value, " #"); i >= 0 {
+			value = value[:i]
+		}
+		out[strings.TrimSpace(key)] = strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return out
+}


### PR DESCRIPTION
Makes the provisioner from #22 usable from the CLI. `hawser install` and `hawser uninstall` now work end to end.

**The locked version manifest (PLAN §04)** is embedded in the binary, so nothing is fetched as "latest at install time" — a given build installs exactly the components it was tested with, today and in six months on a CI runner. Engine selection is **exact**: `--engine-version 29.7` does not resolve to `29.7.2`, because a pin that quietly matches something else isn''t a pin. A test cross-checks the manifest against `guest/rootfs/versions.env` so the two can''t drift silently.

An entry with no checksum is a placeholder (the rootfs release isn''t cut yet), and install refuses it with a message naming the way out. **There is no code path that imports an unverified rootfs** — `--rootfs-url` without `--rootfs-sha256` is a usage error.

Uninstall states what will be destroyed, using the recorded manifest rather than a guess, and asks first. `--yes` for unattended use.

**Two bugs found by actually running it, not by testing it:**

1. My own `ErrNotPublished` message tells users to pass a `file://` URL — and the fetcher couldn''t read one. Local paths and `file://` (including Windows'' `file:///C:/x` spelling) now work, verified identically by checksum: a local rootfs is not more trusted than a downloaded one.
2. After an override install, `hawser version` reported `engine unknown` because no flag carried the version. The rootfs records what it actually contains at `/etc/hawser/engine-version` — more trustworthy than a flag anyway — so install reads it when no explicit version is given.

**Verified end to end against real WSL**, not just mocks: verified download → real `wsl --import` → manifest written despite a deliberately failing engine start → the failure carrying dockerd''s own words (`sh: dockerd: not found`) → `hawser version` reading it back as `engine 29.7.2` → uninstall leaving no distro, data dir or manifest behind. That exercise is what surfaced both bugs above.

Also adds a console log handler: logfmt is right for a service and wrong for a person watching an install.

**Scope note:** this covers #8 and the install half of #9. Bundling the docker CLI and creating the `hawser` docker context is still open in #9 — until then `DOCKER_HOST` is the way in, which the install output says explicitly.

103 → 115 tests; provision 82.6%, release 83.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)