### PR TITLE
Separate rootfs and app release streams; add the app release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: release
+
+# Builds and attaches the hawser binaries when an app release is published.
+#
+# Rootfs releases are a separate namespace (tag prefix rootfs-) handled by
+# rootfs.yml; this workflow skips them so the two never cross-contaminate.
+#
+# Signing is deliberately absent: it lands in v0.4 (#1 milestone), and pretending
+# otherwise would be worse than the honest gap. Checksums are published so a
+# download can at least be verified against the release page.
+
+on:
+  release:
+    types: [published]
+  # Lets the whole build be exercised without publishing anything.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version string to stamp (dry run only, nothing is uploaded)'
+        required: false
+        default: '0.0.0-dryrun'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build binaries
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.release.tag_name, 'rootfs-')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: resolve version
+        id: v
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_EVENT_NAME -eq 'release') {
+            # Strip a leading v so `hawser version` reports 0.1.0, not v0.1.0.
+            $tag = '${{ github.event.release.tag_name }}'
+            $version = $tag -replace '^v', ''
+          } else {
+            $version = '${{ inputs.version }}'
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "building version $version"
+
+      - name: build
+        shell: pwsh
+        env:
+          CGO_ENABLED: '0'
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          # -trimpath keeps absolute build paths out of the binary, so the same
+          # source produces the same bytes on a different machine.
+          foreach ($arch in @('amd64', 'arm64')) {
+            $env:GOOS = 'windows'
+            $env:GOARCH = $arch
+            $out = "dist/hawser_${env:VERSION}_windows_$arch/hawser.exe"
+            New-Item -ItemType Directory -Force (Split-Path $out) | Out-Null
+            go build -trimpath -ldflags "-s -w -X main.buildVersion=$env:VERSION" -o $out ./cmd/hawser
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+            Copy-Item LICENSE, README.md (Split-Path $out)
+            Write-Host "built $out ($([math]::Round((Get-Item $out).Length/1MB,1)) MB)"
+          }
+
+      - name: verify the version stamp and size budget
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          # The amd64 binary runs on this runner, so the release can assert that
+          # the stamp actually took - a release reporting "dev" is a silent
+          # embarrassment that is easy to ship and awkward to withdraw.
+          #
+          # `hawser version` exits 3 when no engine is installed, which is
+          # exactly the state of a CI runner. GitHub's pwsh shell propagates
+          # $LASTEXITCODE, so that expected 3 would fail this step; the exit
+          # code is therefore checked deliberately rather than inherited.
+          $exe = "dist/hawser_${env:VERSION}_windows_amd64/hawser.exe"
+          $json = & $exe version --json
+          $code = $LASTEXITCODE
+          if ($code -ne 0 -and $code -ne 3) {
+            Write-Host "::error::hawser version exited $code"
+            exit 1
+          }
+          $reported = ($json | ConvertFrom-Json).app
+          if ($reported -ne $env:VERSION) {
+            Write-Host "::error::binary reports version '$reported', expected '$env:VERSION'"
+            exit 1
+          }
+          Write-Host "version stamp OK: $reported (exit $code, 3 = no engine installed)"
+
+          # PLAN section 10 budgets under 15 MB for the Windows-side footprint.
+          # Warn rather than fail: the budget covers the installed footprint, and
+          # a release should not be blocked by a metric this workflow only
+          # partially measures.
+          foreach ($f in Get-ChildItem dist -Recurse -Filter hawser.exe) {
+            $mb = [math]::Round($f.Length/1MB, 2)
+            Write-Host "$($f.FullName): $mb MB"
+            if ($mb -gt 15) { Write-Host "::warning::$($f.Name) is $mb MB, over the 15 MB budget" }
+          }
+          # Explicit, so no stray native exit code from above leaks out.
+          exit 0
+
+      - name: package
+        shell: pwsh
+        run: |
+          Push-Location dist
+          foreach ($dir in Get-ChildItem -Directory) {
+            Compress-Archive -Path "$($dir.Name)/*" -DestinationPath "$($dir.Name).zip" -Force
+            Remove-Item -Recurse -Force $dir.Name
+          }
+          # One checksum file covering every artifact, in the usual format.
+          Get-ChildItem -Filter *.zip | ForEach-Object {
+            $h = (Get-FileHash $_.Name -Algorithm SHA256).Hash.ToLower()
+            "$h  $($_.Name)"
+          } | Set-Content SHA256SUMS -Encoding ascii
+          Get-Content SHA256SUMS
+          Pop-Location
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hawser-binaries
+          path: dist/
+          retention-days: 14
+
+  # Separated so only this job holds contents: write. The build job compiles
+  # code and must not be able to publish.
+  publish:
+    name: attach to release
+    needs: build
+    if: github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'rootfs-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: hawser-binaries
+          path: dist
+      - name: upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -6,6 +6,8 @@ on:
     paths: ['guest/rootfs/**', '.github/workflows/rootfs.yml']
   pull_request:
     paths: ['guest/rootfs/**', '.github/workflows/rootfs.yml']
+  # A rootfs release (tag: rootfs-vX.Y.Z) rebuilds and attaches its assets.
+  # App releases are handled by release.yml and skip the publish job below.
   release:
     types: [published]
   workflow_dispatch:
@@ -65,7 +67,11 @@ jobs:
   publish:
     name: attach to release
     needs: build
-    if: github.event_name == 'release'
+    # Only rootfs releases, which carry a rootfs- tag prefix. Without this
+    # check every app release (v0.1.0, previews) would also get rootfs
+    # tarballs attached to it, because the release event does not distinguish
+    # what is being released.
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'rootfs-')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing
+
+Two independent release streams, deliberately kept apart:
+
+| stream | tag | what it publishes | workflow |
+|---|---|---|---|
+| **rootfs** | `rootfs-vX.Y.Z` | the engine tarball, its `.sha256`, and an SPDX SBOM | `rootfs.yml` |
+| **app** | `vX.Y.Z` | `hawser.exe` for amd64 and arm64, zipped, plus `SHA256SUMS` | `release.yml` |
+
+They are separate because the engine and the app version independently: an engine
+security patch should not require an app release, and vice versa (PLAN §04,
+`hawser engine upgrade`). Both workflows check the tag prefix, so a rootfs
+release never gets app binaries attached and an app release never gets a rootfs.
+
+## The ordering that matters
+
+An app release embeds the rootfs checksum in
+[`internal/release/manifest.json`](internal/release/manifest.json). So the rootfs
+has to exist first:
+
+1. **Cut the rootfs release.** Tag `rootfs-v<engine-version>` — e.g.
+   `rootfs-v29.7.2`, matching `ENGINE_VERSION` in `guest/rootfs/versions.env`.
+   Publishing it triggers `rootfs.yml`, which rebuilds from source (or restores
+   the cached binaries), runs the smoke test, and attaches the three assets.
+2. **Copy the published checksum into the manifest.** Take the value from the
+   uploaded `.sha256` and put it in `manifest.json` under
+   `engines[].rootfs.sha256`, confirming the `url` matches the tag you used.
+   Merge that as a normal PR — a test asserts the manifest agrees with
+   `versions.env`.
+3. **Cut the app release.** Tag `v<app-version>`. `release.yml` builds both
+   architectures, asserts the version stamp actually took, packages, and
+   attaches the zips with `SHA256SUMS`.
+
+Until step 2 lands, `hawser install` refuses with a message telling the user to
+pass `--rootfs-url` and `--rootfs-sha256` explicitly. That is intentional: there
+is no code path that installs an unverified rootfs.
+
+## Dry runs
+
+Both workflows can be exercised without publishing:
+
+- `release.yml` — run it from the Actions tab (`workflow_dispatch`) with a
+  version string. It builds, verifies the stamp, packages, and uploads to the
+  workflow's own artifacts, but attaches nothing to any release.
+- `rootfs.yml` — `workflow_dispatch` builds and smoke-tests without publishing.
+
+Worth doing before the first real release of either stream, since release
+plumbing is the kind of thing you want to have already debugged.
+
+## Pre-releases
+
+Use a normal semver pre-release tag (`v0.1.0-preview.1`) and tick **"Set as a
+pre-release"** so it does not become `latest`. Everything else behaves the same.
+Pre-releases are the right way to shake out the pipeline; the version stamp
+check means a preview that reports `dev` fails the build rather than shipping.
+
+## What is not in place yet
+
+- **Code signing.** Lands in v0.4 with Azure Trusted Signing or SignPath. Until
+  then binaries are unsigned and SmartScreen will warn. `SHA256SUMS` is
+  published so a download can be verified, which is not a substitute.
+- **winget / scoop / choco manifests.** Also v0.4.
+- No release currently updates `manifest.json` automatically; step 2 above is
+  deliberately a reviewed commit, because it changes what every install fetches.


### PR DESCRIPTION
Prep for a preview release. Thinking it through found two pipeline bugs *before* a real release could hit them.

**1. `rootfs.yml` published on any release event.** Its publish job was gated only on `github.event_name == ''release''`, so cutting `v0.1.0-preview.1` would have rebuilt the rootfs and attached engine tarballs to the app release. Both workflows now gate on the tag prefix — `rootfs-vX.Y.Z` belongs to `rootfs.yml`, `vX.Y.Z` to `release.yml`, and neither touches the other.

**2. The version-stamp check would have failed while passing.** `release.yml` verifies the stamp by running the binary it just built, and `hawser version` **exits 3 when no engine is installed** — exactly a CI runner''s state. GitHub''s `pwsh` shell propagates `$LASTEXITCODE`, so that expected 3 would have failed the step. Found by running the build logic locally and noticing the exit code. Now checked deliberately rather than inherited.

**What `release.yml` does:** builds amd64 + arm64 with `-trimpath`, asserts the ldflags stamp took (a release reporting `dev` is easy to ship and awkward to withdraw), warns on the 15 MB budget from PLAN §10, packages zips with `SHA256SUMS`, attaches them. Build and publish are **separate jobs so only publish holds `contents: write`** — the job that compiles code cannot publish. `workflow_dispatch` exercises the whole thing without publishing anything.

Verified locally: **amd64 7.2 MB, arm64 6.6 MB** — comfortably under the 15 MB budget — and the stamp reports `0.1.0-preview.1` correctly.

**`RELEASING.md`** documents the two streams and the ordering that matters: the rootfs release must exist before its checksum can go into the embedded manifest, and that step stays a reviewed commit because it changes what every install fetches.

Signing is honestly absent — it''s v0.4 work, and `SHA256SUMS` is not a substitute. Said plainly in the docs rather than glossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)