### PR TITLE
Make the release workflow validate on change (and register at all)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,18 @@ name: release
 on:
   release:
     types: [published]
+
+  # Changes to the release path build immediately, so a mistake here is caught
+  # now rather than discovered while cutting a release. This also makes GitHub
+  # ingest the file at all: a workflow triggered only by release/dispatch is
+  # never parsed until one of those fires, so it stays invisible to
+  # `workflow_dispatch` — which is exactly what happened on the first attempt.
+  push:
+    branches: [main]
+    paths: ['.github/workflows/release.yml']
+  pull_request:
+    paths: ['.github/workflows/release.yml']
+
   # Lets the whole build be exercised without publishing anything.
   workflow_dispatch:
     inputs:
@@ -26,7 +38,7 @@ permissions:
 jobs:
   build:
     name: build binaries
-    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.release.tag_name, 'rootfs-')
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'rootfs-')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +55,11 @@ jobs:
             # Strip a leading v so `hawser version` reports 0.1.0, not v0.1.0.
             $tag = '${{ github.event.release.tag_name }}'
             $version = $tag -replace '^v', ''
-          } else {
+          } elseif ('${{ inputs.version }}') {
             $version = '${{ inputs.version }}'
+          } else {
+            # push / pull_request: a validation build, not a release.
+            $version = '0.0.0-ci'
           }
           "version=$version" >> $env:GITHUB_OUTPUT
           Write-Host "building version $version"


### PR DESCRIPTION
Follow-up to #25. I tried to dry-run the release workflow and got `HTTP 404: workflow release.yml not found on the default branch` — GitHub had never ingested the file.

**Cause:** a workflow triggered only by `release` and `workflow_dispatch` is not parsed until one of those events fires, so it never becomes dispatchable. Chicken and egg, and a silent one — no error anywhere, the workflow simply does not exist as far as the API is concerned.

**Fix:** a path-filtered `push`/`pull_request` trigger. That registers it, and is worth having on its own merits — a mistake in the release path now fails on the commit that introduces it instead of being discovered while cutting a release. Validation builds stamp `0.0.0-ci` and publish nothing, since the publish job is gated on the release event.

Also simplified the build gate to "any non-release event, or a release whose tag is not a rootfs one", which now correctly covers push and pull_request.

This PR touches `release.yml`, so its own `pull_request` trigger should fire and the release build should appear in the checks below — which is the proof that it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)