### PR TITLE
hawser proxy and docker context wiring

### DIFF
--- a/cmd/hawser/console.go
+++ b/cmd/hawser/console.go
@@ -82,3 +82,7 @@ func emitJSON(v any) int {
 	}
 	return exitOK
 }
+
+// interruptCtx is a plain background context for short-lived setup calls that
+// should not be cancelled by the Ctrl-C that stops the long-running server.
+func interruptCtx() context.Context { return context.Background() }

--- a/cmd/hawser/install.go
+++ b/cmd/hawser/install.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/zcsizmadia/hawser/internal/dockerctx"
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
 	"github.com/zcsizmadia/hawser/internal/provision"
 	"github.com/zcsizmadia/hawser/internal/release"
 )
@@ -126,20 +128,58 @@ flags:
 		return emitJSON(manifest)
 	}
 
+	// The context points at whichever pipe the bridge will serve, decided the
+	// same way `hawser proxy` decides it so the two cannot disagree.
+	pipe, pipeReason := pipeproxy.SelectPipeName("")
+	dockerHost := pipeproxy.DockerHostFor(pipe)
+
+	contextReady := false
+	mgr := &dockerctx.Manager{}
+	if err := mgr.Ensure(ctx, dockerHost); err != nil {
+		// A missing docker CLI is not a reason to fail a working install.
+		var noCLI *dockerctx.ErrNoDockerCLI
+		if errors.As(err, &noCLI) {
+			log.Warn("docker context not created", "reason", err)
+		} else {
+			log.Warn("could not wire the docker context", "error", err)
+		}
+	} else {
+		contextReady = true
+	}
+
 	fmt.Printf(`
 Engine installed and running.
 
   distro   %s
   engine   %s
   data     %s
+  pipe     %s  (%s)
 
-Next: point your docker client at it.
+`, manifest.Distro, manifest.EngineVersion, manifest.DataDir, pipe, pipeReason)
 
-  $env:DOCKER_HOST = "npipe:////./pipe/hawser_engine"
+	fmt.Printf(`Start the bridge, then use docker normally:
+
+  hawser proxy
+
+`)
+	if contextReady {
+		fmt.Printf(`In another shell:
+
+  docker --context %s run --rm hello-world
+
+Or make it the default for every shell:
+
+  docker context use %s
+
+`, dockerctx.Name, dockerctx.Name)
+	} else {
+		fmt.Printf(`Then point a docker client at it:
+
+  $env:DOCKER_HOST = "%s"
   docker run --rm hello-world
 
-A `+"`hawser` docker context and a bundled docker CLI are coming in #9;\nuntil then DOCKER_HOST is the way in.\n",
-		manifest.Distro, manifest.EngineVersion, manifest.DataDir)
+`, dockerHost)
+	}
 	return exitOK
 }
 
@@ -195,6 +235,19 @@ flags:
 
 	ctx, stop := interruptible()
 	defer stop()
+
+	// Remove the context before the distro: leaving a context pointed at a
+	// pipe nobody serves would make every later docker command fail, which is
+	// not "nothing else on the system was modified".
+	mgr := &dockerctx.Manager{}
+	if err := mgr.Remove(ctx, ""); err != nil {
+		var noCLI *dockerctx.ErrNoDockerCLI
+		if errors.As(err, &noCLI) {
+			log.Debug("no docker CLI, nothing to unwire", "reason", err)
+		} else {
+			log.Warn("could not remove the docker context", "error", err)
+		}
+	}
 
 	if err := p.Uninstall(ctx, opts); err != nil {
 		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -28,6 +28,7 @@ type command struct {
 func commands() []command {
 	return []command{
 		{"install", "provision the engine distro and start it", runInstall},
+		{"proxy", "serve the docker pipe and relay it to the engine (foreground)", runProxy},
 		{"uninstall", "remove the engine distro and Hawser's state", runUninstall},
 		{"version", "report every component version and which docker.exe is active", runVersion},
 	}

--- a/cmd/hawser/proxy.go
+++ b/cmd/hawser/proxy.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/zcsizmadia/hawser/internal/dockerctx"
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+	"github.com/zcsizmadia/hawser/internal/provision"
+)
+
+func runProxy(args []string) int {
+	fs := flag.NewFlagSet("proxy", flag.ContinueOnError)
+	var (
+		distro     = fs.String("distro", "", "WSL distro to relay to (default: from the install manifest)")
+		stateDir   = fs.String("state-dir", "", "override Hawser's state directory")
+		pipeName   = fs.String("pipe", "", "pipe to serve (default: "+pipeproxy.DefaultPipeName+", or Hawser's own if that is taken)")
+		socketPath = fs.String("socket", provision.EngineSocket, "engine socket inside the distro")
+		noContext  = fs.Bool("no-context", false, "do not create or update the hawser docker context")
+		noRewrite  = fs.Bool("no-path-translation", false, "relay bytes verbatim, without translating Windows bind paths")
+		sddl       = fs.String("sddl", "", "security descriptor for the pipe (advanced; default restricts to SYSTEM, admins and interactive users)")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser proxy [flags]
+
+Serves the Windows named pipe that stock docker.exe connects to, relaying it to
+the engine inside the WSL2 distro. Runs in the foreground until interrupted.
+
+This is the v0.1 way to run the bridge. A Windows service that supervises it
+without a logged-in session is v0.2 work (issue #3).
+
+Exit codes: 0 clean shutdown, %d error, %d usage, %d no engine installed.
+
+flags:
+`, exitError, exitUsage, exitNotFound)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	log := cliLogger(false)
+	opts := provision.Options{Distro: *distro, StateDir: *stateDir}
+
+	// The manifest knows which distro this machine actually has, which matters
+	// when it was installed under a custom name.
+	p := &provision.Provisioner{Logger: log}
+	targetDistro := opts.Distro
+	if m, err := p.ReadManifest(opts); err == nil && m.Distro != "" {
+		targetDistro = m.Distro
+	} else if targetDistro == "" {
+		fmt.Fprintf(os.Stderr,
+			"hawser: no install found. Run `hawser install` first, "+
+				"or pass --distro to relay to an existing distro.\n")
+		return exitNotFound
+	}
+
+	selected, reason := pipeproxy.SelectPipeName(*pipeName)
+	dockerHost := pipeproxy.DockerHostFor(selected)
+
+	listener, err := pipeproxy.Listen(selected, *sddl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	defer listener.Close()
+
+	log.Info("serving pipe", "pipe", selected, "reason", reason)
+	log.Info("relaying to engine", "distro", targetDistro, "socket", *socketPath)
+
+	// Wiring the context is a convenience, not a precondition: a missing docker
+	// CLI must not stop the bridge from running.
+	if !*noContext {
+		mgr := &dockerctx.Manager{}
+		if err := mgr.Ensure(interruptCtx(), dockerHost); err != nil {
+			var noCLI *dockerctx.ErrNoDockerCLI
+			if errors.As(err, &noCLI) {
+				log.Warn("skipping docker context", "reason", err)
+			} else {
+				log.Warn("could not wire the docker context", "error", err)
+			}
+		} else {
+			log.Info("docker context ready", "context", dockerctx.Name, "host", dockerHost)
+		}
+	}
+
+	srv := &pipeproxy.Server{
+		Dialer: &pipeproxy.WSLDialer{
+			Distro:     targetDistro,
+			SocketPath: *socketPath,
+		},
+		Logger: log,
+	}
+	if !*noRewrite {
+		srv.Handler = pipeproxy.RewriteBinds
+	}
+
+	fmt.Fprintf(os.Stderr, `
+Bridge is up. In another shell:
+
+  docker --context %s ps
+  $env:DOCKER_HOST = "%s"; docker ps
+
+Ctrl-C to stop.
+
+`, dockerctx.Name, dockerHost)
+
+	ctx, stop := interruptible()
+	defer stop()
+
+	if err := srv.Serve(ctx, listener); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	log.Info("bridge stopped")
+	return exitOK
+}

--- a/internal/dockerctx/dockerctx.go
+++ b/internal/dockerctx/dockerctx.go
@@ -1,0 +1,192 @@
+// Package dockerctx manages the `hawser` docker context.
+//
+// Contexts are created through the docker CLI rather than by writing
+// ~/.docker/contexts metadata directly. That on-disk layout is an
+// implementation detail Docker has changed before, and hand-writing it would
+// make Hawser the thing that breaks when it changes again. Shelling out costs a
+// process and buys forward compatibility.
+package dockerctx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Name is the context Hawser creates.
+const Name = "hawser"
+
+// Runner executes the docker CLI. Injectable so tests need no docker binary.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// Manager creates, selects and removes the Hawser context.
+type Manager struct {
+	// Docker is the docker executable to drive. Empty resolves through PATH.
+	Docker string
+	// Runner executes commands. Empty uses the real process runner.
+	Runner Runner
+}
+
+// ErrNoDockerCLI reports that no docker executable could be found or run.
+//
+// A distinct type because it is not really a failure: the engine is installed
+// and reachable over DOCKER_HOST regardless, so install should report this and
+// carry on rather than roll back a working engine over a missing convenience.
+type ErrNoDockerCLI struct{ Err error }
+
+func (e *ErrNoDockerCLI) Error() string {
+	return fmt.Sprintf("no working docker CLI found (%v); "+
+		"the engine is still reachable by setting DOCKER_HOST", e.Err)
+}
+
+func (e *ErrNoDockerCLI) Unwrap() error { return e.Err }
+
+func (m *Manager) docker() string {
+	if m.Docker != "" {
+		return m.Docker
+	}
+	return "docker"
+}
+
+func (m *Manager) run(ctx context.Context, args ...string) (string, error) {
+	var out []byte
+	var err error
+	if m.Runner != nil {
+		out, err = m.Runner.Run(ctx, m.docker(), args...)
+	} else {
+		out, err = exec.CommandContext(ctx, m.docker(), args...).CombinedOutput()
+	}
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		// The CLI's own message is the diagnosis; the exit code is not.
+		if text != "" {
+			return text, fmt.Errorf("docker %s: %w: %s",
+				strings.Join(args, " "), err, firstLine(text))
+		}
+		return text, fmt.Errorf("docker %s: %w", strings.Join(args, " "), err)
+	}
+	return text, nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// Available reports whether a usable docker CLI is present.
+func (m *Manager) Available(ctx context.Context) error {
+	if _, err := m.run(ctx, "--version"); err != nil {
+		return &ErrNoDockerCLI{Err: err}
+	}
+	return nil
+}
+
+// Exists reports whether the Hawser context is already defined.
+func (m *Manager) Exists(ctx context.Context) (bool, error) {
+	out, err := m.run(ctx, "context", "ls", "--format", "{{.Name}}")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Endpoint returns the docker host the Hawser context points at.
+func (m *Manager) Endpoint(ctx context.Context) (string, error) {
+	out, err := m.run(ctx, "context", "inspect", Name,
+		"--format", "{{.Endpoints.docker.Host}}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// Ensure creates the Hawser context, or updates it when the endpoint has moved.
+//
+// The endpoint does move: Hawser serves the default pipe when it is free and its
+// own pipe when Docker Desktop holds it, so installing Desktop later changes
+// which pipe is correct. Updating rather than recreating keeps the user's
+// selection intact.
+func (m *Manager) Ensure(ctx context.Context, dockerHost string) error {
+	if dockerHost == "" {
+		return errors.New("dockerctx: dockerHost is required")
+	}
+	if err := m.Available(ctx); err != nil {
+		return err
+	}
+
+	exists, err := m.Exists(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		_, err := m.run(ctx, "context", "create", Name,
+			"--description", "Hawser engine (WSL2)",
+			"--docker", "host="+dockerHost)
+		return err
+	}
+
+	current, err := m.Endpoint(ctx)
+	if err != nil {
+		return err
+	}
+	if current == dockerHost {
+		return nil
+	}
+	_, err = m.run(ctx, "context", "update", Name, "--docker", "host="+dockerHost)
+	return err
+}
+
+// Use selects the Hawser context as the default.
+func (m *Manager) Use(ctx context.Context) error {
+	_, err := m.run(ctx, "context", "use", Name)
+	return err
+}
+
+// Current returns the active context name.
+func (m *Manager) Current(ctx context.Context) (string, error) {
+	out, err := m.run(ctx, "context", "show")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// Remove deletes the Hawser context, restoring a previous selection first.
+//
+// Switching away is required rather than tidy: docker refuses to remove the
+// context in use, and leaving the user pointed at a context that no longer
+// exists would break every subsequent docker command — the opposite of
+// "nothing else on the system was modified".
+func (m *Manager) Remove(ctx context.Context, restoreTo string) error {
+	if err := m.Available(ctx); err != nil {
+		return err
+	}
+	exists, err := m.Exists(ctx)
+	if err != nil || !exists {
+		return err
+	}
+
+	if current, err := m.Current(ctx); err == nil && current == Name {
+		if restoreTo == "" {
+			restoreTo = "default"
+		}
+		if _, err := m.run(ctx, "context", "use", restoreTo); err != nil {
+			return fmt.Errorf("restoring context %q: %w", restoreTo, err)
+		}
+	}
+
+	_, err = m.run(ctx, "context", "rm", Name)
+	return err
+}

--- a/internal/dockerctx/dockerctx_test.go
+++ b/internal/dockerctx/dockerctx_test.go
@@ -1,0 +1,273 @@
+package dockerctx_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/dockerctx"
+)
+
+// fakeDocker records docker CLI invocations and replays canned output, so every
+// argument list is asserted without a docker binary present.
+type fakeDocker struct {
+	calls   [][]string
+	replies map[string]reply
+}
+
+type reply struct {
+	out string
+	err error
+}
+
+func newFakeDocker() *fakeDocker {
+	return &fakeDocker{replies: map[string]reply{
+		"--version": {out: "Docker version 29.7.2, build 6a43e3d"},
+	}}
+}
+
+func (f *fakeDocker) on(prefix, out string, err error) *fakeDocker {
+	f.replies[prefix] = reply{out: out, err: err}
+	return f
+}
+
+func (f *fakeDocker) Run(_ context.Context, _ string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, args)
+	joined := strings.Join(args, " ")
+	// Longest matching prefix wins, so "context ls" beats "context".
+	best, bestLen := reply{err: errors.New("fakeDocker: no reply for " + joined)}, -1
+	for prefix, r := range f.replies {
+		if strings.HasPrefix(joined, prefix) && len(prefix) > bestLen {
+			best, bestLen = r, len(prefix)
+		}
+	}
+	return []byte(best.out), best.err
+}
+
+func (f *fakeDocker) called(prefix string) bool {
+	for _, c := range f.calls {
+		if strings.HasPrefix(strings.Join(c, " "), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeDocker) callWith(prefix string) []string {
+	for _, c := range f.calls {
+		if strings.HasPrefix(strings.Join(c, " "), prefix) {
+			return c
+		}
+	}
+	return nil
+}
+
+const hawserHost = "npipe:////./pipe/hawser_engine"
+
+func TestEnsureCreatesMissingContext(t *testing.T) {
+	f := newFakeDocker().
+		on("context ls", "default\ndesktop-linux", nil).
+		on("context create", "hawser", nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Ensure(context.Background(), hawserHost); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	args := f.callWith("context create")
+	if args == nil {
+		t.Fatal("context was not created")
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "host="+hawserHost) {
+		t.Errorf("create args %q do not set the endpoint", joined)
+	}
+	if f.called("context update") {
+		t.Error("update was called for a context that did not exist")
+	}
+}
+
+func TestEnsureIsIdempotent(t *testing.T) {
+	// Reinstalling, or running proxy repeatedly, must not churn the context.
+	f := newFakeDocker().
+		on("context ls", "default\nhawser", nil).
+		on("context inspect", hawserHost, nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Ensure(context.Background(), hawserHost); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if f.called("context create") {
+		t.Error("create was called for an existing context")
+	}
+	if f.called("context update") {
+		t.Error("update was called when the endpoint already matched")
+	}
+}
+
+func TestEnsureUpdatesMovedEndpoint(t *testing.T) {
+	// The endpoint moves for real: Hawser serves the default pipe when it is
+	// free and its own when Docker Desktop holds it, so installing Desktop
+	// later changes which pipe is correct.
+	f := newFakeDocker().
+		on("context ls", "hawser", nil).
+		on("context inspect", "npipe:////./pipe/docker_engine", nil).
+		on("context update", "hawser", nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Ensure(context.Background(), hawserHost); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	args := f.callWith("context update")
+	if args == nil {
+		t.Fatal("context was not updated")
+	}
+	if !strings.Contains(strings.Join(args, " "), "host="+hawserHost) {
+		t.Errorf("update did not set the new endpoint: %v", args)
+	}
+	if f.called("context create") {
+		t.Error("create was called instead of update, which would lose the selection")
+	}
+}
+
+func TestEnsureRequiresHost(t *testing.T) {
+	m := &dockerctx.Manager{Runner: newFakeDocker()}
+	if err := m.Ensure(context.Background(), ""); err == nil {
+		t.Error("Ensure succeeded with no docker host")
+	}
+}
+
+func TestMissingDockerCLIIsTypedAndNonFatal(t *testing.T) {
+	// Install must be able to distinguish "no docker CLI" (carry on, the engine
+	// works over DOCKER_HOST) from a real failure.
+	f := &fakeDocker{replies: map[string]reply{
+		"--version": {err: errors.New(`exec: "docker": executable file not found in %PATH%`)},
+	}}
+	m := &dockerctx.Manager{Runner: f}
+
+	err := m.Ensure(context.Background(), hawserHost)
+	if err == nil {
+		t.Fatal("Ensure succeeded with no docker CLI")
+	}
+	var noCLI *dockerctx.ErrNoDockerCLI
+	if !errors.As(err, &noCLI) {
+		t.Fatalf("error = %T (%v), want *ErrNoDockerCLI", err, err)
+	}
+	// The message must point at the working alternative.
+	if !strings.Contains(err.Error(), "DOCKER_HOST") {
+		t.Errorf("message should mention DOCKER_HOST: %v", err)
+	}
+	if f.called("context create") {
+		t.Error("tried to create a context without a working CLI")
+	}
+}
+
+func TestExistsDetectsPresenceAndAbsence(t *testing.T) {
+	present := &dockerctx.Manager{Runner: newFakeDocker().
+		on("context ls", "default\nhawser\ndesktop-linux", nil)}
+	if ok, err := present.Exists(context.Background()); err != nil || !ok {
+		t.Errorf("Exists = %v, %v; want true", ok, err)
+	}
+
+	absent := &dockerctx.Manager{Runner: newFakeDocker().
+		on("context ls", "default\ndesktop-linux", nil)}
+	if ok, err := absent.Exists(context.Background()); err != nil || ok {
+		t.Errorf("Exists = %v, %v; want false", ok, err)
+	}
+}
+
+func TestExistsIgnoresSubstringMatches(t *testing.T) {
+	// A context named "hawser-test" must not be mistaken for "hawser".
+	m := &dockerctx.Manager{Runner: newFakeDocker().
+		on("context ls", "default\nhawser-test\nmy-hawser", nil)}
+	if ok, err := m.Exists(context.Background()); err != nil || ok {
+		t.Errorf("Exists = %v, %v; want false for substring matches only", ok, err)
+	}
+}
+
+func TestRemoveSwitchesAwayFirst(t *testing.T) {
+	// docker refuses to remove the context in use, and leaving the user on a
+	// context that no longer exists would break every later docker command.
+	f := newFakeDocker().
+		on("context ls", "default\nhawser", nil).
+		on("context show", "hawser", nil).
+		on("context use", "default", nil).
+		on("context rm", "hawser", nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Remove(context.Background(), "desktop-linux"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	useArgs := f.callWith("context use")
+	if useArgs == nil {
+		t.Fatal("did not switch away before removing")
+	}
+	if got := useArgs[len(useArgs)-1]; got != "desktop-linux" {
+		t.Errorf("restored to %q, want desktop-linux", got)
+	}
+	if !f.called("context rm") {
+		t.Error("context was not removed")
+	}
+}
+
+func TestRemoveDefaultsRestoreTarget(t *testing.T) {
+	f := newFakeDocker().
+		on("context ls", "hawser", nil).
+		on("context show", "hawser", nil).
+		on("context use", "default", nil).
+		on("context rm", "hawser", nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Remove(context.Background(), ""); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	useArgs := f.callWith("context use")
+	if useArgs == nil || useArgs[len(useArgs)-1] != "default" {
+		t.Errorf("restore target = %v, want default", useArgs)
+	}
+}
+
+func TestRemoveSkipsSwitchWhenNotCurrent(t *testing.T) {
+	f := newFakeDocker().
+		on("context ls", "default\nhawser", nil).
+		on("context show", "desktop-linux", nil).
+		on("context rm", "hawser", nil)
+
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Remove(context.Background(), ""); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if f.called("context use") {
+		t.Error("switched contexts even though hawser was not current")
+	}
+}
+
+func TestRemoveOnAbsentContextIsNoOp(t *testing.T) {
+	// Uninstall on a machine where the context was already removed by hand.
+	f := newFakeDocker().on("context ls", "default", nil)
+	m := &dockerctx.Manager{Runner: f}
+	if err := m.Remove(context.Background(), ""); err != nil {
+		t.Errorf("Remove = %v, want nil", err)
+	}
+	if f.called("context rm") {
+		t.Error("tried to remove a context that does not exist")
+	}
+}
+
+func TestErrorsCarryDockerMessage(t *testing.T) {
+	// The CLI's own text is the diagnosis; the exit code says nothing.
+	f := newFakeDocker().
+		on("context ls", "default", nil).
+		on("context create", `context "hawser" already exists`, errors.New("exit status 1"))
+
+	m := &dockerctx.Manager{Runner: f}
+	err := m.Ensure(context.Background(), hawserHost)
+	if err == nil {
+		t.Fatal("Ensure succeeded")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q does not include docker's message", err)
+	}
+}

--- a/internal/pipeproxy/pipename_windows.go
+++ b/internal/pipeproxy/pipename_windows.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package pipeproxy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// PipeInUse reports whether something is already serving a named pipe.
+//
+// Checked by dialing rather than by looking for the file: a pipe exists only
+// while a server holds it, and a stale path with no listener behaves nothing
+// like a live one. A successful dial is closed immediately — this is a probe,
+// not a connection.
+func PipeInUse(name string) bool {
+	timeout := 250 * time.Millisecond
+	conn, err := winio.DialPipe(name, &timeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// SelectPipeName picks the pipe to serve.
+//
+// Hawser prefers the default pipe, because that is what stock docker.exe
+// connects to with no configuration. But it never takes it from Docker Desktop:
+// if something is already listening there, Hawser serves its own pipe instead so
+// the two coexist and trying Hawser stays a zero-risk experiment (PLAN §02).
+//
+// preferred may be empty for DefaultPipeName. The returned reason is worth
+// surfacing to the user, since which pipe is in play determines whether they
+// need DOCKER_HOST.
+func SelectPipeName(preferred string) (name, reason string) {
+	if preferred == "" {
+		preferred = DefaultPipeName
+	}
+
+	// An explicit non-default choice is honored as given; the caller meant it.
+	if preferred != DefaultPipeName {
+		return preferred, "explicitly requested"
+	}
+
+	if !PipeInUse(DefaultPipeName) {
+		return DefaultPipeName, "default pipe is free"
+	}
+	return FallbackPipeName,
+		fmt.Sprintf("%s is already served by another engine (likely Docker Desktop)", DefaultPipeName)
+}
+
+// DockerHostFor renders the DOCKER_HOST value for a pipe, in the npipe form the
+// docker CLI expects. The CLI wants forward slashes even on Windows.
+func DockerHostFor(pipeName string) string {
+	// \\.\pipe\hawser_engine -> npipe:////./pipe/hawser_engine
+	trimmed := pipeName
+	for _, prefix := range []string{`\\.\pipe\`, `//./pipe/`} {
+		if len(trimmed) > len(prefix) && trimmed[:len(prefix)] == prefix {
+			return "npipe:////./pipe/" + trimmed[len(prefix):]
+		}
+	}
+	return "npipe://" + trimmed
+}

--- a/internal/pipeproxy/pipename_windows_test.go
+++ b/internal/pipeproxy/pipename_windows_test.go
@@ -1,0 +1,111 @@
+//go:build windows
+
+package pipeproxy_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+)
+
+func TestDockerHostFor(t *testing.T) {
+	// The docker CLI wants forward slashes even on Windows, so the backslash
+	// pipe name has to be rewritten rather than passed through.
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{`\\.\pipe\docker_engine`, "npipe:////./pipe/docker_engine"},
+		{`\\.\pipe\hawser_engine`, "npipe:////./pipe/hawser_engine"},
+		{"//./pipe/hawser_engine", "npipe:////./pipe/hawser_engine"},
+		{"hawser_custom", "npipe://hawser_custom"},
+	}
+	for _, tt := range tests {
+		if got := pipeproxy.DockerHostFor(tt.in); got != tt.want {
+			t.Errorf("DockerHostFor(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPipeInUseDetectsALiveListener(t *testing.T) {
+	name := fmt.Sprintf(`\\.\pipe\hawser-inuse-%d`, os.Getpid())
+
+	if pipeproxy.PipeInUse(name) {
+		t.Fatalf("%s reported in use before anything listened", name)
+	}
+
+	l, err := pipeproxy.Listen(name, "")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	// Accept in the background: the probe dials, so something must answer.
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			c.(net.Conn).Close()
+		}
+	}()
+
+	if !pipeproxy.PipeInUse(name) {
+		t.Errorf("%s reported free while a listener held it", name)
+	}
+
+	l.Close()
+	if pipeproxy.PipeInUse(name) {
+		t.Errorf("%s still reported in use after the listener closed", name)
+	}
+}
+
+func TestSelectPipeNameHonorsExplicitChoice(t *testing.T) {
+	// An explicit non-default name is taken as given; the caller meant it.
+	custom := `\\.\pipe\hawser-explicit`
+	got, reason := pipeproxy.SelectPipeName(custom)
+	if got != custom {
+		t.Errorf("got %q, want %q", got, custom)
+	}
+	if reason == "" {
+		t.Error("no reason given for the selection")
+	}
+}
+
+func TestSelectPipeNameFallsBackWhenDefaultIsHeld(t *testing.T) {
+	// The behavior that makes trying Hawser zero-risk: it never takes the
+	// default pipe away from Docker Desktop.
+	//
+	// This machine's real state decides which branch runs, so both are
+	// asserted for what they must be rather than which one occurs.
+	got, reason := pipeproxy.SelectPipeName("")
+
+	switch got {
+	case pipeproxy.DefaultPipeName:
+		if pipeproxy.PipeInUse(pipeproxy.DefaultPipeName) {
+			t.Error("chose the default pipe while something else was serving it")
+		}
+		if reason == "" {
+			t.Error("no reason given")
+		}
+	case pipeproxy.FallbackPipeName:
+		if !pipeproxy.PipeInUse(pipeproxy.DefaultPipeName) {
+			t.Error("fell back although the default pipe was free")
+		}
+		if reason == "" {
+			t.Error("fallback must explain itself, since it decides whether the user needs DOCKER_HOST")
+		}
+	default:
+		t.Errorf("chose an unexpected pipe %q", got)
+	}
+}
+
+func TestDefaultAndFallbackPipesDiffer(t *testing.T) {
+	// If these ever collided, coexistence with Docker Desktop would silently
+	// stop working.
+	if pipeproxy.DefaultPipeName == pipeproxy.FallbackPipeName {
+		t.Fatal("default and fallback pipe names are identical")
+	}
+}

--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -161,7 +161,11 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 		handler = func(c net.Conn, e io.ReadWriteCloser) error { return Relay(c, e) }
 	}
 	if err := handler(client, engine); err != nil {
-		log.Debug("connection ended", "error", err)
+		// Warn, not Debug: filterClosed has already dropped the ordinary ways a
+		// docker client hangs up, so anything left is a real fault the user
+		// wants to see. An engine that is down otherwise looks like the bridge
+		// doing nothing at all.
+		log.Warn("connection failed", "error", err)
 	}
 }
 


### PR DESCRIPTION
Closes #9. Also closes the gap that made everything else unreachable: install created a distro, but **nothing served the pipe**, so `docker` had no way in.

- **`hawser proxy`** serves the pipe in the foreground and relays to the distro, path translation on by default. A supervising Windows service is v0.2 (#3); this is the v0.1 way to run the bridge.
- **Pipe selection never takes the default pipe from Docker Desktop.** Hawser prefers `\\.\pipe\docker_engine` when it''s free and serves its own when it''s held, so trying Hawser stays a zero-risk experiment. Presence is probed by *dialing* — a pipe exists only while a server holds it, so checking for the path would be meaningless.
- **`internal/dockerctx`** manages the `hawser` context through the docker CLI rather than by writing `~/.docker/contexts` metadata directly. That layout is an implementation detail Docker has changed before; hand-writing it would make Hawser the thing that breaks next time.
- **Uninstall restores the previous selection before removing the context** — docker refuses to remove the context in use, and leaving the user on a context that no longer exists would break every subsequent docker command. That''s the opposite of "nothing else on the system was modified".
- **A missing docker CLI is typed and non-fatal.** The engine still works over `DOCKER_HOST`, so a working install is never rolled back over a missing convenience.

**One fix found by watching it run:** relay failures were logged at Debug, so an engine that was down looked like the bridge doing nothing at all. They''re Warn now — `filterClosed` already drops the ordinary ways a client hangs up, so what remains is a real fault the operator should see. Confirmed: `warning: connection failed error=read response: unexpected EOF` instead of silence.

**Verified against real WSL and the real docker CLI on a machine running Docker Desktop:**

```
serving pipe pipe=\\.\pipe\hawser_engine
  reason=\\.\pipe\docker_engine is already served by another engine (likely Docker Desktop)
docker context ready context=hawser host=npipe:////./pipe/hawser_engine
```

`docker context ls` showed all three contexts coexisting, `docker --context hawser version` reached the relay, and uninstall removed the context leaving `desktop-linux` selected and Docker Desktop untouched.

Also set the repo About text and topics, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)