### PR TITLE
Mark the Spike B conclusion provisional pending a clean-VM re-test

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,6 +82,8 @@ Never an unauthenticated TCP daemon.
 
 **Supervisor — the always-on layer.** A supervisor process starts with the user's session and keeps the distro and dockerd alive: crash restart, recovery from `wsl --shutdown`, sleep/resume recovery. It runs headless — no UI, no tray required — so a CI runner needs no desktop app, only a session.
 
+> **PROVISIONAL — this conclusion is under re-test.** Spike B ran on a machine whose `SeServiceLogonRight` is missing `NT VIRTUAL MACHINE\Virtual Machines` (S-1-5-83-0), which is the *documented* cause of the very error it measured (`0x80070569`). Interactive WSL works there without the group, but a session-0 VM plausibly needs it, so the failure may be a fixable misconfiguration rather than a platform limit. Re-test belongs on a clean VM without a corporate security baseline. Treat everything below about session 0 as unconfirmed until then. See #3.
+
 It is *not* a session-0 Windows service, and cannot be: Spike B (#3) established that WSL2 will not create its utility VM outside an interactive session. `LocalSystem` is refused outright (`WSL_E_LOCAL_SYSTEM_NOT_SUPPORTED`), and a dedicated service account fails in the Host Compute Service with `ERROR_LOGON_TYPE_NOT_GRANTED` even holding Service, Batch and Interactive logon rights *and* local administrator. This is a WSL platform constraint, not a Hawser one — it binds Docker Desktop, Rancher and `wslc` identically. Unattended machines therefore need a logged-on session, which in practice means auto-logon (§06).
 
 **GUI — deliberately never.** Because Hawser serves the standard Docker API, every existing frontend just works: Portainer, lazydocker, Dockge, VS Code. The README shows the Portainer one-liner — converting "where's the GUI?" into a demo of the compatibility promise.
@@ -236,7 +238,9 @@ hawser status --json   # assert health, then every pipeline step just uses `dock
 
 What makes it first-class rather than incidental: unattended everything (no prompts, meaningful exit codes, `--json`), **version pinning as a contract** (no auto-updates unless asked — determinism is a direct anti-feature of Docker Desktop), **no desktop app required** — a headless supervisor rather than a tray application that pops update dialogs mid-pipeline, MSI/winget for fleet rollout, and pre-baked rootfs VHDX caching so ephemeral runners provision in seconds. GitLab's docker executor pointing at Hawser's pipe for Linux jobs on a Windows runner is a bonus scenario.
 
-**The session requirement, stated plainly.** Spike B (#3) settled this by measurement: **WSL2 cannot create its utility VM outside an interactive session.** `LocalSystem` is refused by name; a dedicated service account fails inside the Host Compute Service with `ERROR_LOGON_TYPE_NOT_GRANTED` even when granted Service, Batch and Interactive logon rights and made a local administrator. There is no privilege left to grant.
+**The session requirement — PROVISIONAL, see the note in §03.** The measurement below came from a machine missing `NT VIRTUAL MACHINE\Virtual Machines` from `SeServiceLogonRight`, a documented cause of the same error code. Until it is re-tested on a clean VM, treat this section as the pessimistic case rather than established fact. If the re-test passes, the original claim is restored and this section reverts.
+
+Spike B (#3) measured: **WSL2 cannot create its utility VM outside an interactive session.** `LocalSystem` is refused by name; a dedicated service account fails inside the Host Compute Service with `ERROR_LOGON_TYPE_NOT_GRANTED` even when granted Service, Batch and Interactive logon rights and made a local administrator. There is no privilege left to grant.
 
 So a runner needs a logged-on session, which for an unattended machine means **auto-logon of a dedicated account**, with Hawser starting at logon. After that one-time setup it is genuinely unattended: no prompts, no human present, reboots recover on their own.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Everything here either de-risks the architecture or claims ground that gets more
 |---|---|---|---|
 | 0.1 | Reserve the name: GitHub org, winget/scoop/choco IDs, domain, USPTO/EUIPO sanity search | reservations done | — |
 | 0.2 | **Spike A — manual end-to-end**: hand-built Alpine+dockerd tar, `wsl --import`, throwaway pipe relay script, `docker ps` from PowerShell (download.docker.com static bundle OK here only) | written spike notes: latency, half-close behavior, gotchas | **GO/NO-GO: the path works at all** |
-| 0.3 | ~~**Spike B — session-0**~~ **DONE (#3): NO-GO.** WSL2 will not create its utility VM outside an interactive session — LocalSystem refused by name, a dedicated account fails in HCS with `ERROR_LOGON_TYPE_NOT_GRANTED` even holding Service+Batch+Interactive rights and local admin | the constraint, measured | CI story now rests on auto-logon; PLAN §03/§06/§09 rewritten |
+| 0.3 | **Spike B — session-0**: **PROVISIONAL NO-GO, re-test pending.** Ran on a machine missing `NT VIRTUAL MACHINE\Virtual Machines` from `SeServiceLogonRight` — the documented cause of the error measured. Re-run on a clean VM. Original finding: WSL2 will not create its utility VM outside an interactive session — LocalSystem refused by name, a dedicated account fails in HCS with `ERROR_LOGON_TYPE_NOT_GRANTED` even holding Service+Batch+Interactive rights and local admin | the constraint, measured | CI story now rests on auto-logon; PLAN §03/§06/§09 rewritten |
 | 0.4 | Repo skeleton: Apache-2.0, Go module, lint/test workflow, layout from PLAN §08 | pushable repo (private) | — |
 | 0.5 | Rootfs CI pipeline v0: Alpine + engine **built from moby/containerd/runc source**, tar + SHA256 + SBOM as release asset | reproducible rootfs artifact | blocks 1.2 |
 


### PR DESCRIPTION
Correction to #30. The NO-GO verdict is **not safe** and is now marked provisional.

**Why:** Spike B ran on a machine whose `SeServiceLogonRight` is missing `NT VIRTUAL MACHINE\Virtual Machines` (S-1-5-83-0). Microsoft documents that exact omission as a cause of `0x80070569` — the precise error the spike measured and built its conclusion on.

Interactive WSL works on that machine without the group (verified: a fresh `wsl --import` succeeds), so nothing is obviously broken. But a VM created from **session 0** plausibly does need it, which is a coherent explanation for "interactive works, service fails" — and would make the failure a **fixable misconfiguration rather than a platform limit.**

**Why it was not re-tested in place:** verifying requires editing user-rights policy on a work machine. `secedit /configure` replaces a right''s membership wholesale rather than appending, so a mistake silently strips rights from other accounts — and that same operation may already have truncated the policy line during the spike, which is part of why it looks so thin now. Not a risk worth taking on someone''s corporate laptop for a research question.

**The right venue is a clean Windows VM**, which also removes a confounder that undermines conclusions in *either* direction: a corporate security baseline means neither a pass nor a fail on that machine generalizes.

**What changed here:** PLAN §03 and §06 carry PROVISIONAL notes, and the ROADMAP gate row says re-test pending. Nothing is reverted — if the re-test passes, those sections revert and the original CI claim is restored.

**Standing product finding regardless of outcome:** `hawser doctor` should check for that group in `SeServiceLogonRight`. It is a documented WSL breakage cause that a corporate baseline can introduce silently, and it presents as an inscrutable hex code.

My error, and the same class I spent the afternoon correcting in #30: stating an inference with more confidence than the evidence carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)