### PR TITLE
Fix release asset upload: gh needs an explicit --repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,10 @@ jobs:
         with:
           name: hawser-binaries
           path: dist
+      # --repo is required: this job downloads artifacts without checking out
+      # the code, so gh has no git remote to infer the repository from and
+      # fails with "not a git repository".
       - name: upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber --repo "${{ github.repository }}"

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -80,7 +80,10 @@ jobs:
         with:
           name: hawser-rootfs
           path: out
+      # --repo is required: this job downloads artifacts without checking out
+      # the code, so gh has no git remote to infer the repository from and
+      # fails with "not a git repository".
       - name: upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" out/* --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" out/* --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
The first real rootfs release exposed a bug the dry runs structurally could not.

`rootfs-v29.7.2` published, the build succeeded and produced all three assets — then the publish job died:

```
gh release upload "rootfs-v29.7.2" out/* --clobber
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

That job downloads artifacts and never checks out the code, so `gh` has no git remote to infer the repository from. Passing `--repo ${{ github.repository }}` fixes it.

**The same bug was in `release.yml`.** Its publish path had never executed — `workflow_dispatch` skips it by design — so the first app release would have hit this too. Fixed in both, with a comment explaining why the flag is needed so it does not get "cleaned up" later.

Worth noting what this says about the dry runs: they verified everything *except* the one step that only a real release can reach. That is a structural limit of dry-running a publish, not an oversight to fix — but it does mean the first release of each stream is itself a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)