### PR TITLE
Record the published rootfs checksum

### DIFF
--- a/internal/release/manifest.json
+++ b/internal/release/manifest.json
@@ -17,7 +17,7 @@
       "default": true,
       "rootfs": {
         "url": "https://github.com/zcsizmadia/hawser/releases/download/rootfs-v29.7.2/hawser-rootfs-29.7.2.tar.gz",
-        "sha256": "2effb0c2bd74a775094a094a0798d1feb0806e0ce478f9a30435b64d903f1e90"
+        "sha256": "155da2c816cc04feb5abf0be7613a3381698314cac099bd7273666ec650535ce"
       },
       "components": {
         "dockerd": "29.7.2",


### PR DESCRIPTION
Points the embedded manifest at the rebuilt `rootfs-v29.7.2`, so **`hawser install` now works with no flags at all.**

Verified end to end against the published release, on a machine also running Docker Desktop:

```
hawser install                  -> exit 0, engine 29.7.2
hawser proxy                    -> serving \\.\pipe\hawser_engine
                                   (fell back; Docker Desktop holds the default)
docker --context hawser version -> client 29.7.2 / server 29.7.2 linux/amd64
docker --context hawser run --rm hello-world
                                -> "Hello from Docker!"
```

That is v0.1''s headline acceptance criterion met for the first time — through the real named pipe, against a rootfs built from upstream source in CI, coexisting with Docker Desktop.

**One defect found while doing it, filed as #35:** the bridge degrades over a session because the relay leaks `wsl.exe`/`socat` children when a client dies mid-request — socat does not exit on stdin EOF, so the relay never returns and never reaps. 12 processes for one proxy, after which every command hangs while dockerd remains perfectly healthy. It does not block install or a first `docker run`, but it should be fixed before v0.1 is tagged.

Worth noting the unit tests could not have caught it: they use a TCP dialer, so there is no child process to leak. The protocol-level half-close assertions are all correct; nothing asserts process lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)