### PR TITLE
Bound the relay process leak (#35)

### DIFF
--- a/internal/pipeproxy/dial_wsl.go
+++ b/internal/pipeproxy/dial_wsl.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
+	"sync"
+	"time"
 )
 
 // WSLDialer reaches the engine socket by running socat inside the distro and
@@ -24,10 +27,52 @@ type WSLDialer struct {
 
 	// Exe overrides the wsl.exe path. Empty uses PATH.
 	Exe string
+
+	// IdleTimeout bounds how long socat will sit on a half-closed connection
+	// with no traffic. Zero uses DefaultIdleTimeout; negative disables it.
+	//
+	// This exists because socat does not exit when its stdin reaches EOF: it
+	// half-closes and waits on the other direction indefinitely. When a docker
+	// client is killed mid-request, that leaves socat — and the wsl.exe holding
+	// it — alive forever, and enough of them make the bridge stop responding
+	// (#35). The timeout is the backstop; the relay closes the engine promptly
+	// in the common case.
+	IdleTimeout time.Duration
 }
+
+// DefaultIdleTimeout is generous enough for a slow `docker build` upload to
+// pause without being torn down, and short enough that a leaked relay is
+// measured in minutes rather than for the life of the session.
+const DefaultIdleTimeout = 5 * time.Minute
 
 // DefaultSocketPath is where dockerd listens inside the Hawser distro.
 const DefaultSocketPath = "/var/run/docker.sock"
+
+func (d *WSLDialer) idleTimeout() time.Duration {
+	switch {
+	case d.IdleTimeout < 0:
+		return 0
+	case d.IdleTimeout == 0:
+		return DefaultIdleTimeout
+	default:
+		return d.IdleTimeout
+	}
+}
+
+// relayArgs builds the wsl.exe argument list for one relay.
+//
+// --exec skips the shell, so nothing re-interprets the socket path and there is
+// no shell process between us and socat.
+func (d *WSLDialer) relayArgs(socket string) []string {
+	args := []string{"-d", d.Distro, "-u", "root", "--exec", "socat"}
+	if t := d.idleTimeout(); t > 0 {
+		// -T is socat's inactivity timeout and applies to the half-closed
+		// state, which is exactly where a client that closed cleanly and then
+		// went away would otherwise strand it forever.
+		args = append(args, "-T", strconv.Itoa(int(t.Seconds())))
+	}
+	return append(args, "STDIO", "UNIX-CONNECT:"+socket)
+}
 
 // Dial starts the relay process and returns its stdio as a connection.
 func (d *WSLDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
@@ -43,13 +88,7 @@ func (d *WSLDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
 		exe = "wsl.exe"
 	}
 
-	// --exec skips the shell, so nothing re-interprets the socket path and
-	// there is no shell process between us and socat.
-	cmd := exec.CommandContext(ctx, exe,
-		"-d", d.Distro,
-		"-u", "root",
-		"--exec", "socat", "STDIO", "UNIX-CONNECT:"+socket,
-	)
+	cmd := exec.CommandContext(ctx, exe, d.relayArgs(socket)...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -74,10 +113,13 @@ func (d *WSLDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
 // genuine half-close — socat sees EOF and shuts down its write side to the
 // engine socket, which is what makes request-body-then-read work.
 type procConn struct {
-	cmd  *exec.Cmd
-	in   io.WriteCloser
-	out  io.ReadCloser
-	done bool
+	cmd *exec.Cmd
+	in  io.WriteCloser
+	out io.ReadCloser
+	// Close can now arrive from two goroutines at once — the relay closes the
+	// engine when the client dies, and handle closes it again on the way out —
+	// so teardown has to be exactly-once rather than merely idempotent-ish.
+	once sync.Once
 }
 
 func (p *procConn) Read(b []byte) (int, error)  { return p.out.Read(b) }
@@ -89,16 +131,17 @@ func (p *procConn) CloseWrite() error { return p.in.Close() }
 // Close tears down the process and reaps it, so a busy client cannot leave a
 // trail of zombie wsl.exe processes behind.
 func (p *procConn) Close() error {
-	if p.done {
-		return nil
-	}
-	p.done = true
-
-	p.in.Close()
-	p.out.Close()
-	if p.cmd.Process != nil {
-		p.cmd.Process.Kill()
-	}
-	p.cmd.Wait()
+	p.once.Do(func() {
+		p.in.Close()
+		p.out.Close()
+		// Only ever this process's own child, by handle. Never by image name:
+		// Docker Desktop, Rancher and the user's own distros all run wsl.exe,
+		// and killing theirs leaves mounts behind that outlive the process
+		// (see the coexistence note on #35).
+		if p.cmd.Process != nil {
+			p.cmd.Process.Kill()
+		}
+		p.cmd.Wait()
+	})
 	return nil
 }

--- a/internal/pipeproxy/dial_wsl_test.go
+++ b/internal/pipeproxy/dial_wsl_test.go
@@ -1,0 +1,64 @@
+package pipeproxy
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The socat idle timeout is the v0.1 backstop for #35. A docker client that is
+// interrupted closes cleanly, which reaches the relay as EOF — indistinguishable
+// from the half-close `docker build` legitimately performs — so the relay cannot
+// tell the two apart and socat never exits on stdin EOF. -T is what bounds the
+// resulting leak, and its absence is invisible until a session degrades hours
+// later, which is exactly why it is asserted here.
+func TestRelayArgsIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    string
+		absent  bool
+	}{
+		{name: "default applied", timeout: 0, want: "-T 300"},
+		{name: "explicit value", timeout: 90 * time.Second, want: "-T 90"},
+		{name: "sub-minute value", timeout: 5 * time.Second, want: "-T 5"},
+		{name: "negative disables", timeout: -1, absent: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &WSLDialer{Distro: "hawser-engine", IdleTimeout: tt.timeout}
+			joined := strings.Join(d.relayArgs(DefaultSocketPath), " ")
+
+			if tt.absent {
+				if strings.Contains(joined, "-T") {
+					t.Errorf("args %q must not contain -T when the timeout is disabled", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tt.want) {
+				t.Errorf("args %q should contain %q", joined, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelayArgsShape(t *testing.T) {
+	d := &WSLDialer{Distro: "hawser-engine", IdleTimeout: -1}
+	got := strings.Join(d.relayArgs("/var/run/docker.sock"), " ")
+	want := "-d hawser-engine -u root --exec socat STDIO UNIX-CONNECT:/var/run/docker.sock"
+	if got != want {
+		t.Errorf("args =\n  %q\nwant\n  %q", got, want)
+	}
+}
+
+func TestIdleTimeoutDefaulting(t *testing.T) {
+	if got := (&WSLDialer{}).idleTimeout(); got != DefaultIdleTimeout {
+		t.Errorf("zero value = %v, want the default %v", got, DefaultIdleTimeout)
+	}
+	if got := (&WSLDialer{IdleTimeout: -5}).idleTimeout(); got != 0 {
+		t.Errorf("negative = %v, want 0 (disabled)", got)
+	}
+	if got := (&WSLDialer{IdleTimeout: time.Minute}).idleTimeout(); got != time.Minute {
+		t.Errorf("explicit = %v, want 1m", got)
+	}
+}

--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -185,6 +185,15 @@ func Relay(client, engine io.ReadWriteCloser) error {
 		defer wg.Done()
 		_, err := io.Copy(engine, client)
 		errs[0] = err
+		if err != nil {
+			// The client died rather than half-closing: nothing is waiting for
+			// a response, and the engine side will not end on its own — socat
+			// does not exit when its stdin closes. Half-closing here would
+			// strand the other direction forever, leaking the relay process
+			// (#35), so tear the engine connection down instead.
+			engine.Close()
+			return
+		}
 		closeWrite(engine)
 	}()
 	go func() {

--- a/internal/pipeproxy/relay_test.go
+++ b/internal/pipeproxy/relay_test.go
@@ -374,3 +374,105 @@ func TestCustomHandlerReplacesRelay(t *testing.T) {
 		t.Error("custom Handler was not called")
 	}
 }
+
+// closeTracker records whether the engine side was fully closed, which is what
+// reaps the relay child in production.
+type closeTracker struct {
+	net.Conn
+	mu          sync.Mutex
+	closed      bool
+	writeClosed bool
+}
+
+func (c *closeTracker) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	return c.Conn.Close()
+}
+
+func (c *closeTracker) CloseWrite() error {
+	c.mu.Lock()
+	c.writeClosed = true
+	c.mu.Unlock()
+	if cw, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
+func (c *closeTracker) state() (closed, writeClosed bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed, c.writeClosed
+}
+
+func TestRelayClosesEngineOnClientError(t *testing.T) {
+	// When the client connection fails outright (reset, pipe broken) the relay
+	// must tear the engine side down rather than half-close it: socat does not
+	// exit on stdin EOF, so half-closing would strand the child (#35).
+	//
+	// Note the limit of this: a client that closes CLEANLY - a Ctrl-C'd docker
+	// CLI - produces EOF, which is indistinguishable from the half-close that
+	// `docker build` legitimately performs. That case is bounded by socat's -T
+	// idle timeout instead, and only fully solved by the v0.2 agent, where
+	// Hawser owns both ends of the connection.
+	engine := newServer(t, func(c net.Conn) { select {} })
+
+	client, server := net.Pipe()
+	econn, err := net.Dial("tcp", engine.l.Addr().String())
+	if err != nil {
+		t.Fatalf("dial engine: %v", err)
+	}
+	tracked := &closeTracker{Conn: econn}
+
+	done := make(chan error, 1)
+	go func() { done <- pipeproxy.Relay(server, tracked) }()
+
+	// Closing the relay's own side surfaces as a read error, not EOF.
+	server.Close()
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Relay did not return after the client connection failed")
+	}
+
+	if closed, _ := tracked.state(); !closed {
+		t.Error("engine connection was not closed, so the relay process would leak")
+	}
+}
+
+func TestRelayHalfClosesOnCleanClientEOF(t *testing.T) {
+	// The other half of the contract: a client that half-closes cleanly (docker
+	// build sending a context, then waiting) must NOT have its engine
+	// connection torn down, or the response is lost.
+	engine := newServer(t, func(c net.Conn) {
+		io.ReadAll(c)
+		io.WriteString(c, "response after half-close")
+	})
+
+	addr, stop := startProxy(t, &pipeproxy.Server{Dialer: engine.dialer()})
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	io.WriteString(c, "request body")
+	if err := c.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	got, err := io.ReadAll(c)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "response after half-close" {
+		t.Errorf("got %q; a clean half-close must still receive the response", got)
+	}
+}


### PR DESCRIPTION
Mitigates #35. Deliberately a *bound*, not a cure — and the PR says so, because writing the test proved the complete fix is not available at this layer.

**What changed**
- socat gets an idle timeout (`-T`, default 5 min). socat does not exit when its stdin reaches EOF; it half-closes and waits on the other direction indefinitely, which is what stranded the relay.
- `Relay` closes the engine outright when the client connection *fails*, instead of half-closing it. A clean half-close still receives its response — asserted, because that is the `docker build` path.
- `procConn` teardown is exactly-once (`sync.Once`); `Close` can now arrive from two goroutines. It kills **only this process''s own child, by handle** — never by image name.

**What is not fixed, and why**

An interrupted `docker` CLI closes its socket *cleanly*. The relay sees EOF — which is indistinguishable from the half-close `docker build` performs when it finishes uploading a context and waits for the response. There is no signal at this layer to tell "the client is waiting" from "the client is gone".

I found this by writing the test for it: `TestRelayClosesEngineWhenClientDies` hung, exactly as production does. Rather than delete the inconvenient test I rewrote it to assert what is actually guaranteed, and documented the gap in the test comment where the next person will meet it.

So the leak is bounded at `IdleTimeout` rather than eliminated. The complete fix belongs to the v0.2 vsock agent, where Hawser owns both ends of the connection and can signal disconnect explicitly.

**Also carried forward as a design constraint** (from the coexistence note on #35): killing another product''s `wsl.exe` left a `/Docker/host` mount behind on this machine and broke Docker Desktop''s WSL integration until it was unmounted by hand. Hawser must never reap by image name, and never call `wsl --shutdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)