### PR TITLE
Supervisor: the always-on layer (v0.2 S1)

### DIFF
--- a/cmd/hawser/detach_windows.go
+++ b/cmd/hawser/detach_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// configureDetached makes the child a windowless, independent process: no
+// console flash, not a member of this console's Ctrl-C group, and alive after
+// this CLI exits — which is the whole point of `hawser start`.
+func configureDetached(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -28,7 +28,12 @@ type command struct {
 func commands() []command {
 	return []command{
 		{"install", "provision the engine distro and start it", runInstall},
-		{"proxy", "serve the docker pipe and relay it to the engine (foreground)", runProxy},
+		{"proxy", "serve the docker pipe in the foreground (debug mode)", runProxy},
+		{"restart", "stop the engine, then start it", runRestart},
+		{"start", "ensure the supervisor and engine are running", runStart},
+		{"status", "report supervisor, engine and desired state", runStatus},
+		{"stop", "stop the engine; it stays stopped until start", runStop},
+		{"supervise", "serve the pipe and keep the engine alive (the always-on layer)", runSupervise},
 		{"uninstall", "remove the engine distro and Hawser's state", runUninstall},
 		{"version", "report every component version and which docker.exe is active", runVersion},
 	}

--- a/cmd/hawser/supervise.go
+++ b/cmd/hawser/supervise.go
@@ -1,0 +1,335 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/dockerctx"
+	"github.com/zcsizmadia/hawser/internal/logging"
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/supervise"
+)
+
+// engineAdapter satisfies supervise.Engine with the provisioner's primitives.
+type engineAdapter struct {
+	p    *provision.Provisioner
+	opts provision.Options
+}
+
+func (e engineAdapter) Running(ctx context.Context) bool {
+	return e.p.EngineRunning(ctx, e.opts)
+}
+func (e engineAdapter) Start(ctx context.Context) error {
+	return e.p.StartEngine(ctx, e.opts)
+}
+func (e engineAdapter) Stop(ctx context.Context) error {
+	return e.p.StopEngine(ctx, e.opts)
+}
+
+// resolveDistro prefers the install manifest, like proxy does: it records
+// which distro this machine actually has.
+func resolveDistro(p *provision.Provisioner, opts provision.Options) (string, bool) {
+	if m, err := p.ReadManifest(opts); err == nil && m.Distro != "" {
+		return m.Distro, true
+	}
+	if opts.Distro != "" {
+		return opts.Distro, true
+	}
+	return "", false
+}
+
+func runSupervise(args []string) int {
+	fs := flag.NewFlagSet("supervise", flag.ContinueOnError)
+	var (
+		distro    = fs.String("distro", "", "WSL distro (default: from the install manifest)")
+		stateDir  = fs.String("state-dir", "", "override Hawser's state directory")
+		pipeName  = fs.String("pipe", "", "pipe to serve (default: "+pipeproxy.DefaultPipeName+", or Hawser's own if taken)")
+		noContext = fs.Bool("no-context", false, "do not create or update the hawser docker context")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser supervise [flags]
+
+The always-on layer: serves the docker pipe AND keeps the engine alive —
+crash restart with backoff, recovery from `+"`wsl --shutdown`"+` and sleep/resume,
+honoring `+"`hawser stop`"+` until `+"`hawser start`"+`. One instance per install.
+
+Runs in the foreground; `+"`hawser start`"+` spawns it in the background, and the
+logon autostart (upcoming) runs it for you. Logs go to supervisor.log in the
+state directory (rotated) as well as stderr.
+
+flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := provision.Options{Distro: *distro, StateDir: *stateDir}
+	opts = optsWithResolvedStateDir(opts)
+
+	// Single instance before anything else: two supervisors would fight over
+	// the pipe and the engine.
+	lock, err := supervise.Acquire(opts.StateDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	defer lock.Close()
+
+	// Log to a rotating file and stderr both: the file for the months-long
+	// logon session, stderr for a human running it in the foreground.
+	logFile, err := logging.NewRotatingWriter(
+		filepath.Join(opts.StateDir, "supervisor.log"), 0, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	defer logFile.Close()
+	log := slog.New(slog.NewTextHandler(io.MultiWriter(logFile, os.Stderr), nil))
+
+	p := &provision.Provisioner{Logger: log}
+	targetDistro, ok := resolveDistro(p, opts)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "hawser: no install found. Run `hawser install` first.")
+		return exitNotFound
+	}
+	opts.Distro = targetDistro
+
+	selected, reason := pipeproxy.SelectPipeName(*pipeName)
+	listener, err := pipeproxy.Listen(selected, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	defer listener.Close()
+	log.Info("serving pipe", "pipe", selected, "reason", reason)
+
+	if !*noContext {
+		if err := (&dockerctx.Manager{}).Ensure(context.Background(),
+			pipeproxy.DockerHostFor(selected)); err != nil {
+			log.Warn("docker context not wired", "reason", err)
+		}
+	}
+
+	ctx, stop := interruptible()
+	defer stop()
+
+	// The reconciler keeps the engine matching the desired state...
+	sup := &supervise.Supervisor{
+		Engine: engineAdapter{p: p, opts: opts},
+		Config: supervise.Config{StateDir: opts.StateDir},
+		Log:    log,
+	}
+	go sup.Run(ctx)
+
+	// ...while the pipe server carries traffic. Both stop together.
+	srv := &pipeproxy.Server{
+		Dialer:  &pipeproxy.WSLDialer{Distro: targetDistro},
+		Logger:  log,
+		Handler: pipeproxy.RewriteBinds,
+	}
+	if err := srv.Serve(ctx, listener); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	log.Info("supervisor stopped")
+	return exitOK
+}
+
+// optsWithResolvedStateDir freezes the default state dir into the options, so
+// lock names, logs and desired-state files all agree on one path.
+func optsWithResolvedStateDir(opts provision.Options) provision.Options {
+	if opts.StateDir == "" {
+		if base := os.Getenv("LOCALAPPDATA"); base != "" {
+			opts.StateDir = filepath.Join(base, "Hawser")
+		}
+	}
+	return opts
+}
+
+func runStart(args []string) int {
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	stateDir := fs.String("state-dir", "", "override Hawser's state directory")
+	timeout := fs.Duration("timeout", 2*time.Minute, "how long to wait for the engine")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser start
+
+Records the desired state as running, launches the supervisor when none is
+running, and waits for the engine to answer.
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
+	if err := supervise.WriteDesired(opts.StateDir, supervise.DesiredRunning); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+
+	p := &provision.Provisioner{Logger: cliLogger(false)}
+	distro, ok := resolveDistro(p, opts)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "hawser: no install found. Run `hawser install` first.")
+		return exitNotFound
+	}
+	// The resolved name must actually be used: polling the default distro
+	// while the install lives under a custom name reports a healthy engine as
+	// missing — the poll timed out while `hawser status` said running.
+	opts.Distro = distro
+
+	if !supervise.Held(opts.StateDir) {
+		fmt.Fprintln(os.Stderr, "  starting the supervisor in the background")
+		if err := spawnSupervisor(opts.StateDir); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: launching supervisor: %v\n", err)
+			return exitError
+		}
+	}
+
+	deadline := time.Now().Add(*timeout)
+	for time.Now().Before(deadline) {
+		if p.EngineRunning(context.Background(), opts) {
+			fmt.Println("engine is running")
+			return exitOK
+		}
+		time.Sleep(time.Second)
+	}
+	fmt.Fprintf(os.Stderr, "hawser: engine did not come up within %s; see supervisor.log in %s\n",
+		*timeout, opts.StateDir)
+	return exitError
+}
+
+func runStop(args []string) int {
+	fs := flag.NewFlagSet("stop", flag.ContinueOnError)
+	stateDir := fs.String("state-dir", "", "override Hawser's state directory")
+	timeout := fs.Duration("timeout", time.Minute, "how long to wait for the engine to stop")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser stop
+
+Records the desired state as stopped and waits for the engine to stop. The
+supervisor keeps honoring this until `+"`hawser start`"+` — a stopped engine stays
+stopped. Only Hawser's own distro is touched, never other WSL distros.
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
+	if err := supervise.WriteDesired(opts.StateDir, supervise.DesiredStopped); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+
+	p := &provision.Provisioner{Logger: cliLogger(false)}
+	distro, ok := resolveDistro(p, opts)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "hawser: no install found; nothing to stop")
+		return exitNotFound
+	}
+	opts.Distro = distro
+
+	// With no supervisor to do it, stop the engine directly.
+	if !supervise.Held(opts.StateDir) {
+		if err := p.StopEngine(context.Background(), opts); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+	}
+
+	deadline := time.Now().Add(*timeout)
+	for time.Now().Before(deadline) {
+		if !p.EngineRunning(context.Background(), opts) {
+			fmt.Println("engine is stopped (and stays stopped until `hawser start`)")
+			return exitOK
+		}
+		time.Sleep(time.Second)
+	}
+	fmt.Fprintf(os.Stderr, "hawser: engine still running after %s\n", *timeout)
+	return exitError
+}
+
+func runRestart(args []string) int {
+	if code := runStop(args); code != exitOK && code != exitNotFound {
+		return code
+	}
+	return runStart(args)
+}
+
+func runStatus(args []string) int {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	stateDir := fs.String("state-dir", "", "override Hawser's state directory")
+	asJSON := fs.Bool("json", false, "emit machine-readable JSON")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
+	p := &provision.Provisioner{Logger: cliLogger(true)}
+
+	st := struct {
+		Installed  bool   `json:"installed"`
+		Distro     string `json:"distro,omitempty"`
+		Supervisor string `json:"supervisor"`
+		Engine     string `json:"engine"`
+		Desired    string `json:"desired"`
+	}{
+		Supervisor: "stopped",
+		Engine:     "stopped",
+		Desired:    string(supervise.ReadDesired(opts.StateDir)),
+	}
+
+	if distro, ok := resolveDistro(p, opts); ok {
+		st.Installed = true
+		st.Distro = distro
+		opts.Distro = distro
+		if supervise.Held(opts.StateDir) {
+			st.Supervisor = "running"
+		}
+		if p.EngineRunning(context.Background(), opts) {
+			st.Engine = "running"
+		}
+	}
+
+	if *asJSON {
+		return emitJSON(st)
+	}
+	if !st.Installed {
+		fmt.Println("not installed (run `hawser install`)")
+		return exitNotFound
+	}
+	fmt.Printf("distro      %s\nsupervisor  %s\nengine      %s\ndesired     %s\n",
+		st.Distro, st.Supervisor, st.Engine, st.Desired)
+	// Exit code mirrors engine health, so scripts can gate on it directly.
+	if st.Engine != "running" {
+		return exitError
+	}
+	return exitOK
+}
+
+// spawnSupervisor launches `hawser supervise` detached and windowless.
+func spawnSupervisor(stateDir string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(self, "supervise", "--state-dir", stateDir)
+	configureDetached(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Released, not waited on: it must outlive this CLI invocation.
+	return cmd.Process.Release()
+}

--- a/internal/logging/rotate.go
+++ b/internal/logging/rotate.go
@@ -1,0 +1,109 @@
+// Package logging provides the rotating file writer the supervisor logs to.
+//
+// Rotation is size-based and self-contained rather than a dependency: the
+// engine's own logs rotate inside the distro (daemon.json), so this only
+// covers Hawser's supervisor — a low-volume log that must simply never eat the
+// disk on a machine that stays logged on for months (PLAN §05 v0.2).
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// RotatingWriter is an io.Writer that caps the file at MaxBytes and keeps a
+// bounded number of predecessors (log, log.1, log.2, ...).
+type RotatingWriter struct {
+	path     string
+	maxBytes int64
+	keep     int
+
+	mu   sync.Mutex
+	f    *os.File
+	size int64
+}
+
+// NewRotatingWriter opens (or creates) path for appending. maxBytes <= 0
+// defaults to 5 MB; keep <= 0 defaults to 3 predecessors.
+func NewRotatingWriter(path string, maxBytes int64, keep int) (*RotatingWriter, error) {
+	if maxBytes <= 0 {
+		maxBytes = 5 * 1024 * 1024
+	}
+	if keep <= 0 {
+		keep = 3
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("creating log dir: %w", err)
+	}
+	w := &RotatingWriter{path: path, maxBytes: maxBytes, keep: keep}
+	if err := w.open(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *RotatingWriter) open() error {
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening log: %w", err)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("stat log: %w", err)
+	}
+	w.f = f
+	w.size = st.Size()
+	return nil
+}
+
+// Write appends, rotating first when the write would cross the cap. A single
+// write larger than the cap still lands (in a fresh file) rather than being
+// dropped: losing the one huge record — a panic trace, say — would discard
+// exactly the evidence rotation exists to preserve.
+func (w *RotatingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
+		if err := w.rotate(); err != nil {
+			// Rotation failing must not lose log lines; keep appending to the
+			// oversized file and let the next write retry the rotation.
+			fmt.Fprintf(os.Stderr, "hawser: log rotation failed: %v\n", err)
+		}
+	}
+
+	n, err := w.f.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotate shifts path -> path.1 -> path.2 ... dropping the oldest.
+func (w *RotatingWriter) rotate() error {
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	// Shift from the oldest end so each rename lands on a free name.
+	os.Remove(fmt.Sprintf("%s.%d", w.path, w.keep))
+	for i := w.keep - 1; i >= 1; i-- {
+		os.Rename(fmt.Sprintf("%s.%d", w.path, i), fmt.Sprintf("%s.%d", w.path, i+1))
+	}
+	if err := os.Rename(w.path, w.path+".1"); err != nil && !os.IsNotExist(err) {
+		// Reopen regardless: appending must survive a failed rename.
+		w.open()
+		return err
+	}
+	return w.open()
+}
+
+// Close flushes and closes the current file.
+func (w *RotatingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f != nil {
+		return w.f.Close()
+	}
+	return nil
+}

--- a/internal/logging/rotate_test.go
+++ b/internal/logging/rotate_test.go
@@ -1,0 +1,121 @@
+package logging_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/logging"
+)
+
+func TestRotatesAtCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.log")
+	w, err := logging.NewRotatingWriter(path, 100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	line := strings.Repeat("x", 39) + "\n" // 40 bytes
+	for i := 0; i < 10; i++ {              // 400 bytes total
+		if _, err := w.Write([]byte(line)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Current file stays under the cap; predecessors exist; count is bounded.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() > 100 {
+		t.Errorf("current log is %d bytes, cap is 100", st.Size())
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Error("no rotated predecessor .1")
+	}
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Error(".3 exists; keep=2 must bound the trail")
+	}
+}
+
+func TestOversizedRecordStillLands(t *testing.T) {
+	// One record larger than the cap must be written, not dropped: the huge
+	// record is usually the panic trace rotation exists to preserve.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.log")
+	w, err := logging.NewRotatingWriter(path, 50, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	w.Write([]byte("small\n"))
+	big := strings.Repeat("B", 200)
+	if _, err := w.Write([]byte(big)); err != nil {
+		t.Fatalf("oversized write failed: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), big) {
+		t.Error("oversized record was not preserved in the current file")
+	}
+}
+
+func TestSurvivesReopen(t *testing.T) {
+	// The supervisor restarts across logons; appending must continue, and the
+	// recorded size must come from the file rather than assumed zero, or the
+	// cap drifts upward forever.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.log")
+
+	w1, err := logging.NewRotatingWriter(path, 100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w1.Write([]byte(strings.Repeat("a", 60) + "\n"))
+	w1.Close()
+
+	w2, err := logging.NewRotatingWriter(path, 100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w2.Close()
+	w2.Write([]byte(strings.Repeat("b", 60) + "\n")) // must trigger rotation
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Error("rotation did not account for pre-existing size after reopen")
+	}
+}
+
+func TestManyRotationsKeepBound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.log")
+	w, err := logging.NewRotatingWriter(path, 50, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(w, "%04d %s\n", i, strings.Repeat("y", 20))
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 4 { // s.log + .1 + .2 + .3
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("%d log files %v; keep=3 must bound this at 4", len(entries), names)
+	}
+}

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -355,3 +355,20 @@ func (p *Provisioner) ReadManifest(opts Options) (*Manifest, error) {
 	}
 	return &m, nil
 }
+
+// EngineRunning reports whether the engine socket answers inside the distro.
+func (p *Provisioner) EngineRunning(ctx context.Context, opts Options) bool {
+	opts = opts.withDefaults()
+	running, _ := p.engineRunning(ctx, opts)
+	return running
+}
+
+// StopEngine terminates the engine's own distro — and nothing else. This is
+// the only stop primitive Hawser has on purpose: `wsl --shutdown` stops every
+// distro on the machine, including Docker Desktop's and the user's own, and is
+// never called (PLAN §02; the coexistence note on #35).
+func (p *Provisioner) StopEngine(ctx context.Context, opts Options) error {
+	opts = opts.withDefaults()
+	p.logger().Info("terminating distro", "distro", opts.Distro)
+	return p.wsl().Terminate(ctx, opts.Distro)
+}

--- a/internal/supervise/lock_windows.go
+++ b/internal/supervise/lock_windows.go
@@ -1,0 +1,79 @@
+//go:build windows
+
+package supervise
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// Lock is a held single-instance claim. Release with Close; the OS also
+// releases it if the process dies, which is the property a PID file cannot
+// offer without staleness heuristics.
+type Lock struct {
+	handle windows.Handle
+}
+
+// lockName derives a per-install mutex name: two Hawser installs with
+// different state dirs (the e2e suite next to a real install, say) must not
+// exclude each other. Session-local (`Local\`), because the supervisor is a
+// per-user, per-session concern.
+func lockName(stateDir string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(stateDir)))
+	return `Local\hawser-supervisor-` + hex.EncodeToString(sum[:8])
+}
+
+// ErrAlreadyRunning reports a second supervisor for the same install.
+type ErrAlreadyRunning struct{ StateDir string }
+
+func (e *ErrAlreadyRunning) Error() string {
+	return fmt.Sprintf("a supervisor for %s is already running "+
+		"(two would fight over the pipe); use `hawser status` to see it", e.StateDir)
+}
+
+// Acquire claims the single-instance lock, failing fast if held elsewhere.
+func Acquire(stateDir string) (*Lock, error) {
+	name, err := windows.UTF16PtrFromString(lockName(stateDir))
+	if err != nil {
+		return nil, err
+	}
+	h, err := windows.CreateMutex(nil, true, name)
+	// CreateMutex succeeds even when the mutex exists; ownership is the part
+	// that matters, reported via ERROR_ALREADY_EXISTS.
+	if err == windows.ERROR_ALREADY_EXISTS {
+		if h != 0 {
+			windows.CloseHandle(h)
+		}
+		return nil, &ErrAlreadyRunning{StateDir: stateDir}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("acquiring supervisor lock: %w", err)
+	}
+	return &Lock{handle: h}, nil
+}
+
+// Held reports whether some process holds the lock, without taking it. Used by
+// `hawser status` and by `hawser start` to decide whether to spawn a
+// supervisor.
+func Held(stateDir string) bool {
+	l, err := Acquire(stateDir)
+	if err != nil {
+		return true // held (or unqueryable, which reads the same to a caller)
+	}
+	l.Close()
+	return false
+}
+
+// Close releases the claim.
+func (l *Lock) Close() error {
+	if l.handle != 0 {
+		windows.ReleaseMutex(l.handle)
+		windows.CloseHandle(l.handle)
+		l.handle = 0
+	}
+	return nil
+}

--- a/internal/supervise/state.go
+++ b/internal/supervise/state.go
@@ -1,0 +1,61 @@
+// Package supervise keeps the engine alive: a health loop with backoff,
+// driven by a desired state the CLI writes and the supervisor honors.
+//
+// The desired state lives in a file rather than a control socket on purpose.
+// `hawser stop` must mean *stays* stopped — without a recorded intent, the
+// health loop would helpfully restart the engine the user just stopped, and
+// the two would fight. A file also works when the supervisor is not running
+// at all, which is exactly when `hawser start` needs somewhere to leave its
+// instruction.
+package supervise
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Desired is what the user last asked for.
+type Desired string
+
+const (
+	// DesiredRunning means the health loop keeps the engine up. The default:
+	// installing Hawser is itself the request to have a working engine.
+	DesiredRunning Desired = "running"
+	// DesiredStopped means the health loop keeps the engine down.
+	DesiredStopped Desired = "stopped"
+)
+
+func statePath(stateDir string) string {
+	return filepath.Join(stateDir, "desired-state")
+}
+
+// ReadDesired returns the recorded intent, defaulting to running when nothing
+// was ever recorded.
+func ReadDesired(stateDir string) Desired {
+	b, err := os.ReadFile(statePath(stateDir))
+	if err != nil {
+		return DesiredRunning
+	}
+	if Desired(strings.TrimSpace(string(b))) == DesiredStopped {
+		return DesiredStopped
+	}
+	return DesiredRunning
+}
+
+// WriteDesired records the intent atomically, so a crash mid-write cannot
+// leave a state the reader misparses into an unintended restart.
+func WriteDesired(stateDir string, d Desired) error {
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	tmp := statePath(stateDir) + ".tmp"
+	if err := os.WriteFile(tmp, []byte(d+"\n"), 0o644); err != nil {
+		return fmt.Errorf("writing desired state: %w", err)
+	}
+	if err := os.Rename(tmp, statePath(stateDir)); err != nil {
+		return fmt.Errorf("committing desired state: %w", err)
+	}
+	return nil
+}

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -1,0 +1,137 @@
+package supervise
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Engine is what the supervisor drives. The seam matches what the provisioner
+// and wsl packages already offer, and lets the loop be tested without WSL.
+type Engine interface {
+	// Running reports whether the engine socket answers.
+	Running(ctx context.Context) bool
+	// Start brings the engine up (idempotent; provisioner.StartEngine).
+	Start(ctx context.Context) error
+	// Stop terminates the engine's own distro — and only that distro. Stopping
+	// anything wider (another distro, wsl --shutdown) is off the table by
+	// design: Hawser shares the machine (PLAN §02, the Docker Desktop incident
+	// on #35).
+	Stop(ctx context.Context) error
+}
+
+// Config tunes the loop. Zero values get defaults.
+type Config struct {
+	// StateDir is where the desired state is read from.
+	StateDir string
+	// Interval between health checks. Also bounds how quickly a CLI-written
+	// desired-state change is noticed. Default 3s.
+	Interval time.Duration
+	// BackoffMax caps the restart backoff. Default 60s.
+	BackoffMax time.Duration
+}
+
+func (c Config) interval() time.Duration {
+	if c.Interval <= 0 {
+		return 3 * time.Second
+	}
+	return c.Interval
+}
+
+func (c Config) backoffMax() time.Duration {
+	if c.BackoffMax <= 0 {
+		return 60 * time.Second
+	}
+	return c.BackoffMax
+}
+
+// Supervisor reconciles the engine with the desired state.
+type Supervisor struct {
+	Engine Engine
+	Config Config
+	Log    *slog.Logger
+
+	// failures counts consecutive start failures, for backoff.
+	failures int
+	// nextTry is the earliest moment another start attempt is allowed.
+	nextTry time.Time
+}
+
+func (s *Supervisor) log() *slog.Logger {
+	if s.Log != nil {
+		return s.Log
+	}
+	return slog.Default()
+}
+
+// Run reconciles until the context ends. It never returns an error for the
+// engine being down — that is a condition to repair, not a reason to exit —
+// and it survives sleep/resume for free: a resumed machine simply fails the
+// next health check and gets repaired like any other crash.
+func (s *Supervisor) Run(ctx context.Context) {
+	t := time.NewTicker(s.Config.interval())
+	defer t.Stop()
+
+	// Reconcile immediately rather than waiting out the first tick: the
+	// supervisor usually starts at logon, and the user is waiting.
+	s.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			s.log().Info("supervisor stopping", "reason", ctx.Err())
+			return
+		case <-t.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *Supervisor) tick(ctx context.Context) {
+	desired := ReadDesired(s.Config.StateDir)
+	up := s.Engine.Running(ctx)
+
+	switch {
+	case desired == DesiredRunning && !up:
+		if time.Now().Before(s.nextTry) {
+			return // still backing off
+		}
+		s.log().Warn("engine is down; starting it", "consecutiveFailures", s.failures)
+		if err := s.Engine.Start(ctx); err != nil {
+			s.failures++
+			delay := s.backoff()
+			s.nextTry = time.Now().Add(delay)
+			s.log().Error("engine start failed",
+				"error", err, "retryIn", delay, "consecutiveFailures", s.failures)
+			return
+		}
+		s.failures = 0
+		s.nextTry = time.Time{}
+		s.log().Info("engine recovered")
+
+	case desired == DesiredStopped && up:
+		s.log().Info("desired state is stopped; stopping the engine")
+		if err := s.Engine.Stop(ctx); err != nil {
+			s.log().Error("engine stop failed", "error", err)
+		}
+
+	case desired == DesiredRunning && up:
+		// Healthy: a success observed by the loop also resets backoff, so one
+		// bad patch (a WSL update mid-flight, say) does not tax the next.
+		s.failures = 0
+		s.nextTry = time.Time{}
+	}
+}
+
+// backoff is exponential from 2s, capped: crash loops must not hammer WSL,
+// but a transient failure (sleep/resume races, `wsl --shutdown`) should be
+// repaired in seconds, not minutes.
+func (s *Supervisor) backoff() time.Duration {
+	d := 2 * time.Second
+	for i := 1; i < s.failures; i++ {
+		d *= 2
+		if d >= s.Config.backoffMax() {
+			return s.Config.backoffMax()
+		}
+	}
+	return d
+}

--- a/internal/supervise/supervise_test.go
+++ b/internal/supervise/supervise_test.go
@@ -1,0 +1,230 @@
+package supervise_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/supervise"
+)
+
+// fakeEngine is a scriptable engine with call counting.
+type fakeEngine struct {
+	mu       sync.Mutex
+	running  bool
+	startErr error
+	starts   int
+	stops    int
+}
+
+func (f *fakeEngine) Running(context.Context) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running
+}
+
+func (f *fakeEngine) Start(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.starts++
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.running = true
+	return nil
+}
+
+func (f *fakeEngine) Stop(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stops++
+	f.running = false
+	return nil
+}
+
+func (f *fakeEngine) counts() (starts, stops int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.starts, f.stops
+}
+
+func (f *fakeEngine) setRunning(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running = v
+}
+
+func quiet() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func newSup(t *testing.T, e supervise.Engine, interval time.Duration) (*supervise.Supervisor, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return &supervise.Supervisor{
+		Engine: e,
+		Config: supervise.Config{StateDir: dir, Interval: interval},
+		Log:    quiet(),
+	}, dir
+}
+
+// waitFor polls until cond holds or the deadline passes.
+func waitFor(t *testing.T, d time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+func TestStartsDownEngine(t *testing.T) {
+	e := &fakeEngine{}
+	sup, _ := newSup(t, e, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	waitFor(t, 3*time.Second, func() bool { s, _ := e.counts(); return s >= 1 && e.Running(ctx) },
+		"engine was never started")
+}
+
+func TestRestartsAfterCrash(t *testing.T) {
+	// The wsl --shutdown / crash / resume shape: engine was healthy, drops,
+	// must come back without any user action (PLAN §05 v0.2 exit criteria).
+	e := &fakeEngine{running: true}
+	sup, _ := newSup(t, e, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	time.Sleep(100 * time.Millisecond) // a few healthy ticks
+	e.setRunning(false)                // crash
+
+	waitFor(t, 3*time.Second, func() bool { return e.Running(ctx) },
+		"engine was not restarted after a crash")
+}
+
+func TestHonorsDesiredStopped(t *testing.T) {
+	// `hawser stop` must mean *stays* stopped: without honoring recorded
+	// intent, the health loop would restart the engine the user just stopped.
+	e := &fakeEngine{running: true}
+	sup, dir := newSup(t, e, 20*time.Millisecond)
+	if err := supervise.WriteDesired(dir, supervise.DesiredStopped); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	waitFor(t, 3*time.Second, func() bool { return !e.Running(ctx) },
+		"engine was not stopped despite desired=stopped")
+
+	// And it must STAY stopped across many ticks.
+	time.Sleep(200 * time.Millisecond)
+	if starts, _ := e.counts(); starts != 0 {
+		t.Errorf("engine was started %d times while desired=stopped", starts)
+	}
+}
+
+func TestStopThenStartRoundTrip(t *testing.T) {
+	e := &fakeEngine{running: true}
+	sup, dir := newSup(t, e, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	if err := supervise.WriteDesired(dir, supervise.DesiredStopped); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 3*time.Second, func() bool { return !e.Running(ctx) }, "did not stop")
+
+	if err := supervise.WriteDesired(dir, supervise.DesiredRunning); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 3*time.Second, func() bool { return e.Running(ctx) }, "did not start again")
+}
+
+func TestBackoffLimitsStartAttempts(t *testing.T) {
+	// A crash loop must not hammer WSL: with starts failing continuously,
+	// attempts should be spaced out, not one per tick.
+	e := &fakeEngine{startErr: errors.New("engine keeps dying")}
+	sup, _ := newSup(t, e, 10*time.Millisecond)
+	sup.Config.BackoffMax = time.Hour // make the cap irrelevant here
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	sup.Run(ctx)
+
+	starts, _ := e.counts()
+	// 500ms of 10ms ticks is ~50 opportunities; with 2s-and-up backoff only
+	// the first attempt (plus at most one race) should have happened.
+	if starts > 2 {
+		t.Errorf("engine start attempted %d times in 500ms; backoff is not holding", starts)
+	}
+}
+
+func TestBackoffResetsOnRecovery(t *testing.T) {
+	e := &fakeEngine{startErr: errors.New("still broken")}
+	sup, _ := newSup(t, e, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	waitFor(t, time.Second, func() bool { s, _ := e.counts(); return s >= 1 },
+		"no start attempt")
+
+	// Repair the engine out of band (as a human or WSL itself might); once the
+	// loop sees it healthy, backoff state must clear so the NEXT failure is
+	// retried promptly rather than inheriting the old penalty.
+	e.mu.Lock()
+	e.startErr = nil
+	e.running = true
+	e.mu.Unlock()
+
+	time.Sleep(100 * time.Millisecond) // healthy ticks observe it
+
+	e.setRunning(false) // fresh crash
+	waitFor(t, 3*time.Second, func() bool { return e.Running(ctx) },
+		"fresh crash after recovery was not repaired promptly")
+}
+
+func TestDesiredStateDefaultsToRunning(t *testing.T) {
+	if got := supervise.ReadDesired(t.TempDir()); got != supervise.DesiredRunning {
+		t.Errorf("default desired = %q, want running", got)
+	}
+}
+
+func TestDesiredStateRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	for _, d := range []supervise.Desired{supervise.DesiredStopped, supervise.DesiredRunning} {
+		if err := supervise.WriteDesired(dir, d); err != nil {
+			t.Fatal(err)
+		}
+		if got := supervise.ReadDesired(dir); got != d {
+			t.Errorf("read %q after writing %q", got, d)
+		}
+	}
+}
+
+func TestGarbageDesiredStateReadsAsRunning(t *testing.T) {
+	// A corrupted file must fail toward the default, not toward stopped:
+	// silently keeping the engine down would read as "Hawser is broken".
+	dir := t.TempDir()
+	if err := supervise.WriteDesired(dir, "garbage-value"); err != nil {
+		t.Fatal(err)
+	}
+	if got := supervise.ReadDesired(dir); got != supervise.DesiredRunning {
+		t.Errorf("garbage state read as %q, want running", got)
+	}
+}


### PR DESCRIPTION
Implements the core of #39: one long-lived `hawser supervise` process owning both the pipe server and an engine reconciler, with `start/stop/restart/status` as real commands. `hawser proxy` stays as foreground debug mode.

**Desired-state driven, and that''s the design decision worth reviewing.** `hawser stop` records intent in a file the loop honors — without it, the health loop would helpfully restart the engine the user just stopped. A file rather than a control socket because it also works when no supervisor is running, which is exactly when `hawser start` needs somewhere to leave its instruction. Corrupt state fails toward *running*: an engine silently kept down reads as "Hawser is broken."

**Crash recovery verified on real WSL, zero clicks:**

```
wsl --terminate hawser-sup
engine right after kill:      stopped
engine after supervisor tick: running
docker version               -> server 29.7.2
```

Sleep/resume needs no special handling *by construction* — a resumed machine fails the next health check and is repaired like any crash. Backoff is exponential (2s→60s cap) so a crash loop can''t hammer WSL, and resets on observed health.

**Boundaries, from the #35 incident:** stop terminates only Hawser''s own distro; there is deliberately no wider primitive. Single instance via a per-install named mutex (`Local\`, hashed state dir) — the OS releases it if the process dies, which is the property a PID file can''t offer without staleness heuristics.

**One bug found by running it** (the sixteenth this project has caught that way): `runStart` resolved the install''s distro to verify it exists, then discarded it — so it polled the *default* distro name and reported a timeout while `hawser status` said running. Plus one self-inflicted lesson: you can''t rebuild a binary that''s currently running as your own supervisor.

13 new tests; **the 13-stage acceptance suite is still green end to end** with the supervisor in the tree.

**Deliberately deferred within #39:** autostart-at-logon (registering logon tasks without a console flash has real Windows subtleties worth a focused change) and the Event Log sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)