### PR TITLE
Autostart at logon (hawserw launcher) + Event Log mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,13 @@ jobs:
             New-Item -ItemType Directory -Force (Split-Path $out) | Out-Null
             go build -trimpath -ldflags "-s -w -X main.buildVersion=$env:VERSION" -o $out ./cmd/hawser
             if ($LASTEXITCODE -ne 0) { exit 1 }
+            # hawserw is the windowless logon launcher (GUI subsystem, so no
+            # console flashes at startup); autostart refuses without it.
+            $outw = "dist/hawser_${env:VERSION}_windows_$arch/hawserw.exe"
+            go build -trimpath -ldflags "-s -w -H=windowsgui" -o $outw ./cmd/hawserw
+            if ($LASTEXITCODE -ne 0) { exit 1 }
             Copy-Item LICENSE, README.md (Split-Path $out)
-            Write-Host "built $out ($([math]::Round((Get-Item $out).Length/1MB,1)) MB)"
+            Write-Host "built $out ($([math]::Round((Get-Item $out).Length/1MB,1)) MB) + hawserw"
           }
 
       - name: verify the version stamp and size budget

--- a/cmd/hawser/autostart.go
+++ b/cmd/hawser/autostart.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/zcsizmadia/hawser/internal/autostart"
+)
+
+func runAutostart(args []string) int {
+	fs := flag.NewFlagSet("autostart", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `usage: hawser autostart enable|disable|status
+
+Controls whether the supervisor starts at logon, via a per-user Run entry
+(visible and switchable in Task Manager's Startup tab; no admin needed). The
+entry runs hawserw.exe, the windowless launcher, so nothing flashes at logon.
+
+install registers this by default; uninstall removes it.
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	switch fs.Arg(0) {
+	case "enable":
+		exe, err := os.Executable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		if err := autostart.Enable(exe); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		fmt.Println("autostart enabled: the supervisor starts at your next logon")
+		return exitOK
+
+	case "disable":
+		if err := autostart.Disable(); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		fmt.Println("autostart disabled (a running supervisor is not stopped; use `hawser stop`)")
+		return exitOK
+
+	case "status", "":
+		enabled, cmd, err := autostart.Status()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		if enabled {
+			fmt.Printf("enabled: %s\n", cmd)
+			return exitOK
+		}
+		fmt.Println("disabled")
+		return exitNotFound
+
+	default:
+		fs.Usage()
+		return exitUsage
+	}
+}

--- a/cmd/hawser/install.go
+++ b/cmd/hawser/install.go
@@ -8,8 +8,11 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 
+	"github.com/zcsizmadia/hawser/internal/autostart"
 	"github.com/zcsizmadia/hawser/internal/dockerctx"
+	"github.com/zcsizmadia/hawser/internal/logging"
 	"github.com/zcsizmadia/hawser/internal/pipeproxy"
 	"github.com/zcsizmadia/hawser/internal/provision"
 	"github.com/zcsizmadia/hawser/internal/release"
@@ -39,6 +42,7 @@ func runInstall(args []string) int {
 		dataDir       = fs.String("data-dir", "", "where the distro's VHDX lives (default: under the state dir)")
 		stateDir      = fs.String("state-dir", "", "override Hawser's state directory")
 		headless      = fs.Bool("headless", false, "never prompt; for unattended and CI installs")
+		noAutostart   = fs.Bool("no-autostart", false, "do not register the supervisor to start at logon")
 		rootfsURL     = fs.String("rootfs-url", "", "override the rootfs URL (development)")
 		rootfsSHA     = fs.String("rootfs-sha256", "", "expected rootfs SHA-256; required with --rootfs-url")
 		asJSON        = fs.Bool("json", false, "emit the resulting manifest as JSON")
@@ -133,6 +137,28 @@ flags:
 	pipe, pipeReason := pipeproxy.SelectPipeName("")
 	dockerHost := pipeproxy.DockerHostFor(pipe)
 
+	// Autostart is registered by default: "install once, docker ps works
+	// forever" is the headline promise, and a supervisor that only runs when
+	// launched by hand does not deliver it. Refusal is honest, not fatal —
+	// missing hawserw.exe (a bare go-build binary rather than a release zip)
+	// downgrades to a warning with the manual alternative named.
+	if !*noAutostart {
+		if exe, err := os.Executable(); err == nil {
+			if err := autostart.Enable(exe); err != nil {
+				log.Warn("autostart not registered", "reason", err,
+					"fix", "run `hawser start` after each logon, or `hawser autostart enable` from a release install")
+			} else {
+				log.Info("supervisor will start at logon", "disable", "hawser autostart disable")
+			}
+		}
+	}
+
+	// Registering the Event Log source needs elevation; cosmetic when absent
+	// (entries render with a boilerplate prefix), so best-effort by design.
+	if err := logging.RegisterEventSource(); err != nil {
+		log.Debug("event log source not registered (needs elevation; cosmetic)", "error", err)
+	}
+
 	contextReady := false
 	mgr := &dockerctx.Manager{}
 	if err := mgr.Ensure(ctx, dockerHost); err != nil {
@@ -157,13 +183,13 @@ Engine installed and running.
 
 `, manifest.Distro, manifest.EngineVersion, manifest.DataDir, pipe, pipeReason)
 
-	fmt.Printf(`Start the bridge, then use docker normally:
+	fmt.Printf(`Start the always-on bridge:
 
-  hawser proxy
+  hawser start
 
 `)
 	if contextReady {
-		fmt.Printf(`In another shell:
+		fmt.Printf(`Then use docker normally:
 
   docker --context %s run --rm hello-world
 
@@ -179,6 +205,10 @@ Or make it the default for every shell:
   docker run --rm hello-world
 
 `, dockerHost)
+	}
+	if !*noAutostart {
+		fmt.Println("From your next logon the supervisor starts automatically;")
+		fmt.Println("`hawser autostart disable` turns that off.")
 	}
 	return exitOK
 }
@@ -235,6 +265,22 @@ flags:
 
 	ctx, stop := interruptible()
 	defer stop()
+
+	// Autostart goes first: a Run entry pointing at a binary that is about to
+	// stop having anything to supervise would relaunch a supervisor into an
+	// empty install at next logon. Ownership-checked, so uninstalling a
+	// secondary install (the e2e suite beside a real one) cannot delete the
+	// primary install's entry.
+	if exe, err := os.Executable(); err == nil {
+		if removed, err := autostart.DisableIfOwned(filepath.Dir(exe)); err != nil {
+			log.Warn("could not remove the autostart entry", "error", err)
+		} else if removed {
+			log.Info("autostart entry removed")
+		}
+	}
+	if err := logging.UnregisterEventSource(); err != nil {
+		log.Debug("event log source not unregistered (needs elevation; cosmetic)", "error", err)
+	}
 
 	// Remove the context before the distro: leaving a context pointed at a
 	// pipe nobody serves would make every later docker command fail, which is

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -27,6 +27,7 @@ type command struct {
 
 func commands() []command {
 	return []command{
+		{"autostart", "start the supervisor at logon: enable, disable, status", runAutostart},
 		{"install", "provision the engine distro and start it", runInstall},
 		{"proxy", "serve the docker pipe in the foreground (debug mode)", runProxy},
 		{"restart", "stop the engine, then start it", runRestart},

--- a/cmd/hawser/supervise.go
+++ b/cmd/hawser/supervise.go
@@ -94,7 +94,10 @@ flags:
 		return exitError
 	}
 	defer logFile.Close()
-	log := slog.New(slog.NewTextHandler(io.MultiWriter(logFile, os.Stderr), nil))
+	// Warn+ mirrors to the Event Log for admins; the file keeps everything.
+	log := slog.New(logging.NewEventLogHandler(
+		slog.NewTextHandler(io.MultiWriter(logFile, os.Stderr), nil),
+		logging.EventSource))
 
 	p := &provision.Provisioner{Logger: log}
 	targetDistro, ok := resolveDistro(p, opts)

--- a/cmd/hawserw/main.go
+++ b/cmd/hawserw/main.go
@@ -1,0 +1,43 @@
+// Command hawserw is the windowless launcher for the supervisor — the javaw
+// convention. It exists because hawser.exe is a console binary, and anything
+// that starts a console binary at logon (a Run key, an interactive scheduled
+// task) flashes a console window at the user. hawserw is built for the GUI
+// subsystem (-H=windowsgui), so no console is ever created; it spawns
+// `hawser supervise` hidden and exits.
+//
+// If a supervisor is already running, supervise itself exits via its
+// single-instance lock; hawserw does not need to care.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func main() {
+	self, err := os.Executable()
+	if err != nil {
+		os.Exit(1)
+	}
+	// The sibling console binary does the real work; keeping the launcher a
+	// spawner rather than a second copy of the CLI keeps the zip honest about
+	// where behavior lives.
+	hawser := filepath.Join(filepath.Dir(self), "hawser.exe")
+	if _, err := os.Stat(hawser); err != nil {
+		os.Exit(1)
+	}
+
+	cmd := exec.Command(hawser, append([]string{"supervise"}, os.Args[1:]...)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+	if err := cmd.Start(); err != nil {
+		os.Exit(1)
+	}
+	cmd.Process.Release()
+}

--- a/internal/autostart/autostart_windows.go
+++ b/internal/autostart/autostart_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+// Package autostart registers the supervisor to start at logon.
+//
+// The mechanism is the per-user Run key rather than a scheduled task, for
+// three reasons that all trace back to constraints this project has already
+// measured: it needs no elevation (install must work non-admin), it produces
+// an *interactive* process in the user's session (a "run whether logged on or
+// not" task performs a batch logon into session 0, where WSL cannot start —
+// Spike B, #3), and it is trivially inspectable and removable by the user in
+// Task Manager's Startup tab. The registered command is hawserw.exe, the
+// GUI-subsystem launcher, so no console flashes at logon.
+package autostart
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// ValueName is the Run-key entry name; visible to users in Task Manager.
+const ValueName = "Hawser"
+
+// runKeyPath is a var so tests can point at a scratch key instead of the
+// user's real Run key.
+var runKeyPath = `Software\Microsoft\Windows\CurrentVersion\Run`
+
+// Enable registers hawserw.exe (next to the given hawser.exe) to run at logon.
+func Enable(hawserExe string) error {
+	launcher := filepath.Join(filepath.Dir(hawserExe), "hawserw.exe")
+	if _, err := os.Stat(launcher); err != nil {
+		return fmt.Errorf("autostart needs the hawserw.exe launcher next to hawser.exe "+
+			"(a console binary at logon would flash a console window): %w", err)
+	}
+
+	k, err := registry.OpenKey(registry.CURRENT_USER, runKeyPath, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("opening the Run key: %w", err)
+	}
+	defer k.Close()
+
+	// Quoted, because the install dir may contain spaces.
+	if err := k.SetStringValue(ValueName, `"`+launcher+`"`); err != nil {
+		return fmt.Errorf("writing the Run entry: %w", err)
+	}
+	return nil
+}
+
+// Disable removes the logon entry. Removing an entry that does not exist is
+// success: the user asked for a state, not an action.
+func Disable() error {
+	k, err := registry.OpenKey(registry.CURRENT_USER, runKeyPath, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("opening the Run key: %w", err)
+	}
+	defer k.Close()
+
+	if err := k.DeleteValue(ValueName); err != nil && err != registry.ErrNotExist {
+		return fmt.Errorf("removing the Run entry: %w", err)
+	}
+	return nil
+}
+
+// DisableIfOwned removes the logon entry only when it points into the given
+// install directory. The Run entry is one-per-user while installs are
+// per-state-dir, so an uninstall of a secondary install (the e2e suite runs
+// one beside a real install, with its binary in a temp dir) must not delete
+// the entry belonging to the primary. Returns whether an entry was removed.
+func DisableIfOwned(installDir string) (bool, error) {
+	enabled, cmd, err := Status()
+	if err != nil || !enabled {
+		return false, err
+	}
+	registered := strings.ToLower(filepath.Clean(strings.Trim(cmd, `"`)))
+	dir := strings.ToLower(filepath.Clean(installDir))
+	if !strings.HasPrefix(registered, dir+string(filepath.Separator)) {
+		return false, nil // someone else's entry; leave it alone
+	}
+	return true, Disable()
+}
+
+// Status returns whether autostart is registered, and the command if so.
+func Status() (enabled bool, command string, err error) {
+	k, err := registry.OpenKey(registry.CURRENT_USER, runKeyPath, registry.QUERY_VALUE)
+	if err != nil {
+		return false, "", fmt.Errorf("opening the Run key: %w", err)
+	}
+	defer k.Close()
+
+	v, _, err := k.GetStringValue(ValueName)
+	if err == registry.ErrNotExist {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("reading the Run entry: %w", err)
+	}
+	return true, v, nil
+}

--- a/internal/autostart/autostart_windows_test.go
+++ b/internal/autostart/autostart_windows_test.go
@@ -1,0 +1,138 @@
+//go:build windows
+
+package autostart
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// useScratchKey points the package at a disposable key so tests never touch
+// the user's real Run key.
+func useScratchKey(t *testing.T) {
+	t.Helper()
+	orig := runKeyPath
+	runKeyPath = `Software\HawserTest\Run`
+
+	// The scratch key must exist for OpenKey(SET_VALUE) to succeed.
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, runKeyPath, registry.ALL_ACCESS)
+	if err != nil {
+		t.Fatalf("creating scratch key: %v", err)
+	}
+	k.Close()
+
+	t.Cleanup(func() {
+		registry.DeleteKey(registry.CURRENT_USER, runKeyPath)
+		registry.DeleteKey(registry.CURRENT_USER, `Software\HawserTest`)
+		runKeyPath = orig
+	})
+}
+
+// fakeInstall lays out hawser.exe + hawserw.exe in a temp dir.
+func fakeInstall(t *testing.T, withLauncher bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "hawser.exe")
+	if err := os.WriteFile(exe, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if withLauncher {
+		if err := os.WriteFile(filepath.Join(dir, "hawserw.exe"), []byte("stub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return exe
+}
+
+func TestEnableStatusDisableRoundTrip(t *testing.T) {
+	useScratchKey(t)
+	exe := fakeInstall(t, true)
+
+	if err := Enable(exe); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+
+	enabled, cmd, err := Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !enabled {
+		t.Fatal("not enabled after Enable")
+	}
+	if !strings.Contains(cmd, "hawserw.exe") {
+		t.Errorf("registered command %q must run the windowless launcher, not the console binary", cmd)
+	}
+	if !strings.HasPrefix(cmd, `"`) {
+		t.Errorf("command %q is unquoted; a space in the install path would break it", cmd)
+	}
+
+	if err := Disable(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if enabled, _, _ := Status(); enabled {
+		t.Error("still enabled after Disable")
+	}
+}
+
+func TestEnableRefusesWithoutLauncher(t *testing.T) {
+	useScratchKey(t)
+	exe := fakeInstall(t, false)
+
+	err := Enable(exe)
+	if err == nil {
+		t.Fatal("Enable succeeded without hawserw.exe; a console binary at logon flashes a window")
+	}
+	if !strings.Contains(err.Error(), "hawserw.exe") {
+		t.Errorf("error should name the missing launcher: %v", err)
+	}
+	if enabled, _, _ := Status(); enabled {
+		t.Error("a refused Enable must not leave a Run entry behind")
+	}
+}
+
+func TestDisableWhenAbsentIsSuccess(t *testing.T) {
+	useScratchKey(t)
+	// The user asked for a state, not an action.
+	if err := Disable(); err != nil {
+		t.Errorf("Disable with no entry = %v, want nil", err)
+	}
+}
+
+func TestDisableIfOwnedProtectsOtherInstalls(t *testing.T) {
+	// The Run entry is one-per-user while installs are per-state-dir, so
+	// uninstalling a secondary install (the e2e suite beside a real one) must
+	// not delete the primary's entry.
+	useScratchKey(t)
+	primary := fakeInstall(t, true)
+	if err := Enable(primary); err != nil {
+		t.Fatal(err)
+	}
+
+	secondaryDir := t.TempDir() // different install, no entry of its own
+	removed, err := DisableIfOwned(secondaryDir)
+	if err != nil {
+		t.Fatalf("DisableIfOwned: %v", err)
+	}
+	if removed {
+		t.Fatal("uninstalling a secondary install removed the primary's autostart entry")
+	}
+	if enabled, _, _ := Status(); !enabled {
+		t.Fatal("primary's entry is gone")
+	}
+
+	// The owner, however, must remove it.
+	removed, err = DisableIfOwned(filepath.Dir(primary))
+	if err != nil {
+		t.Fatalf("DisableIfOwned(owner): %v", err)
+	}
+	if !removed {
+		t.Fatal("the owning install could not remove its own entry")
+	}
+	if enabled, _, _ := Status(); enabled {
+		t.Fatal("entry still present after the owner removed it")
+	}
+}

--- a/internal/logging/eventlog_windows.go
+++ b/internal/logging/eventlog_windows.go
@@ -1,0 +1,82 @@
+//go:build windows
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// EventLogHandler mirrors Warn-and-above records to the Windows Event Log,
+// wrapping another handler that receives everything.
+//
+// Only warnings and errors: the Event Log is where an admin looks when
+// something is wrong, and routine health-loop chatter there would train them
+// to ignore the source. The rotating file keeps the full story.
+//
+// Registration caveat, stated rather than hidden: writing under an
+// unregistered source works, but Event Viewer prefixes entries with "the
+// description for Event ID ... cannot be found" before showing the message.
+// Proper source registration writes HKLM and so needs elevation; install does
+// it best-effort when elevated and skips silently when not.
+type EventLogHandler struct {
+	inner slog.Handler
+	log   *eventlog.Log
+}
+
+// NewEventLogHandler wraps inner. When the Event Log cannot be opened at all,
+// inner is returned unwrapped: losing the mirror must not cost the file log.
+func NewEventLogHandler(inner slog.Handler, source string) slog.Handler {
+	l, err := eventlog.Open(source)
+	if err != nil {
+		return inner
+	}
+	return &EventLogHandler{inner: inner, log: l}
+}
+
+// EventSource is the name entries appear under.
+const EventSource = "Hawser"
+
+// RegisterEventSource creates the HKLM registration so Event Viewer renders
+// entries cleanly. Needs elevation; callers treat failure as cosmetic.
+func RegisterEventSource() error {
+	return eventlog.InstallAsEventCreate(EventSource,
+		eventlog.Error|eventlog.Warning|eventlog.Info)
+}
+
+// UnregisterEventSource removes the registration; same elevation caveat.
+func UnregisterEventSource() error {
+	return eventlog.Remove(EventSource)
+}
+
+func (h *EventLogHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.inner.Enabled(ctx, l)
+}
+
+func (h *EventLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelWarn && h.log != nil {
+		msg := r.Message
+		r.Attrs(func(a slog.Attr) bool {
+			msg += " " + a.Key + "=" + a.Value.String()
+			return true
+		})
+		// Mirror failures are swallowed: the file log is authoritative, and an
+		// Event Log hiccup must never break supervision.
+		if r.Level >= slog.LevelError {
+			h.log.Error(1, msg)
+		} else {
+			h.log.Warning(1, msg)
+		}
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *EventLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &EventLogHandler{inner: h.inner.WithAttrs(attrs), log: h.log}
+}
+
+func (h *EventLogHandler) WithGroup(name string) slog.Handler {
+	return &EventLogHandler{inner: h.inner.WithGroup(name), log: h.log}
+}


### PR DESCRIPTION
Completes #39 (v0.2 S1): after `hawser install`, the supervisor starts automatically at every logon with zero clicks.

## What

- **`internal/autostart`** — per-user Run key (`HKCU\...\CurrentVersion\Run`, value `Hawser`). Chosen over a scheduled task because it needs no elevation, produces an *interactive* process in the user''s session (a batch-logon task lands in session 0 where WSL cannot start — Spike B, #3), and is user-inspectable in Task Manager''s Startup tab.
- **`cmd/hawserw`** — GUI-subsystem launcher (`-H=windowsgui`, javaw convention): spawns sibling `hawser.exe supervise` hidden, so no console flashes at logon. `Enable` refuses when hawserw.exe is missing and names the manual alternative.
- **`hawser autostart enable|disable|status`** — status exits 3 when disabled, matching the version/status convention.
- **Install wiring** — autostart on by default, `--no-autostart` opts out; failure is a warning, not a failed install.
- **Ownership-checked uninstall** — `DisableIfOwned(installDir)` removes the Run entry only when it points into the uninstalling install''s own directory, so a secondary install (the e2e suite runs one beside a real install) cannot delete the primary''s entry. Covered by a test.
- **Event Log mirror** — supervisor wraps its rotating-file handler with `EventLogHandler` (Warn+ only; routine chatter would train admins to ignore the source). Source registration needs elevation → best-effort at install, cosmetic when absent.
- **release.yml** — builds `hawserw.exe` for amd64 + arm64 into the same zips.

## Testing

- Unit: all packages green, incl. real HKCU round-trip against a scratch key and the ownership test.
- Acceptance: `go test -tags e2e -count=1` full 13-stage suite green (39s), incl. Uninstall/NothingLeftBehind with the new wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)