### PR TITLE
Spike C: AF_HYPERV host-to-guest vsock — GO for #40

### DIFF
--- a/spike/c/README.md
+++ b/spike/c/README.md
@@ -1,0 +1,64 @@
+# Spike C: AF_HYPERV from Windows into the WSL2 utility VM
+
+The mini-spike gating #40 (vsock guest agent). Question: can a **standard,
+non-elevated** Windows process dial into a vsock listener inside the WSL2
+utility VM — and in particular, can it discover the VM's GUID, which
+`hcsdiag list` refuses to reveal without Hyper-V-admin rights?
+
+## Verdict: GO
+
+Run on 2026-09-01, Windows 11 Pro 26200, WSL2, standard (non-admin) user,
+with Docker Desktop's distro running in the same utility VM:
+
+```
+discovered 1 compute system(s) without elevation: [EAAC9D05-…]
+vm EAAC9D05-…: CONNECTED, banner="hawser-spike-c hello from the guest", first connect+banner=4.005ms
+per-connection cost over 50 dials: avg 574.456µs
+PASS
+```
+
+Findings, in the order #40 needs them:
+
+1. **VM-GUID discovery needs no elevation.** The Host Compute Service mirrors
+   every running compute system into
+   `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\HostComputeService\VolatileStore\ComputeSystem`,
+   and that key is readable by standard users. All WSL2 distros of a session
+   share one utility VM, so with WSL running there is exactly one candidate
+   (Docker Desktop's distro lives in the same VM — verified live). The key
+   only exists while something is running, which is fine: the supervisor
+   starts the distro before the agent.
+2. **The dial itself is unprivileged.** go-winio's `Dial` with
+   `HvsockAddr{VMID, VsockServiceID(port)}` connects as a plain user; no
+   service registration under `GuestCommunicationServices` is needed in the
+   host→guest direction (registration is only for guest→host listeners).
+3. **The guest side is plain AF_VSOCK.** Bind `VMADDR_CID_ANY`, listen,
+   accept. `/dev/vsock` is present in stock WSL2 distros.
+4. **The host arrives as CID 2** (`VMADDR_CID_HOST`), so the agent can and
+   should reject any peer with a different CID.
+5. **Per-connection cost ~0.6 ms** vs the ~165 ms socat path measured in
+   Spike A — the #40 latency target ("within 2× Docker Desktop") is cleared
+   by two orders of magnitude.
+
+One sharp edge to carry into the real design: the VolatileStore key lists
+*compute systems*, which on a busy machine could include non-WSL utility VMs
+(other HCS consumers). The spike handles it the way the agent should: try each
+candidate; only the VM actually running our listener answers on our port.
+The agent's banner/handshake makes a wrong-VM connection fail closed.
+
+## Kit
+
+- `guest/`: AF_VSOCK echo listener (Go, linux) — the exact socket code the
+  real agent will use. `GOOS=linux go build`, copy into any WSL2 distro, run
+  with a port argument.
+- `host/`: discovery + dial + latency probe (Go, windows). `go build`, run
+  `host.exe -n 50`; `-vm` overrides discovery, `-port` matches the guest.
+- `run.ps1`: builds both, starts the listener in a distro (default Ubuntu),
+  runs the probe, cleans up.
+
+## What this unlocks in #40
+
+Owning both ends removes the EOF ambiguity that made #35 only *boundable*
+with socat (a Ctrl-C'd CLI and a build's half-close look identical to socat's
+stdin). The agent relays vsock⇄`/var/run/docker.sock` per connection, the
+supervisor keeps it alive with the engine, and the socat path stays as the
+automatic fallback for a rootfs that predates the agent.

--- a/spike/c/guest/go.mod
+++ b/spike/c/guest/go.mod
@@ -1,0 +1,5 @@
+module github.com/zcsizmadia/hawser/spike/c/guest
+
+go 1.23
+
+require golang.org/x/sys v0.30.0

--- a/spike/c/guest/go.sum
+++ b/spike/c/guest/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/spike/c/guest/main.go
+++ b/spike/c/guest/main.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+// Spike C guest: an AF_VSOCK echo listener, standing in for the future
+// hawser-agent (#40). Listens on the given port for connections from the
+// Windows host, sends a banner, then echoes until EOF.
+//
+// This is the exact socket family the real agent will use; if this accepts a
+// connection from the host probe, the transport question of #40 is settled.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	port := uint32(5000)
+	if len(os.Args) > 1 {
+		p, err := strconv.ParseUint(os.Args[1], 10, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad port %q: %v\n", os.Args[1], err)
+			os.Exit(2)
+		}
+		port = uint32(p)
+	}
+
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "socket(AF_VSOCK): %v\n", err)
+		os.Exit(1)
+	}
+	// VMADDR_CID_ANY: the guest does not need to know its own CID.
+	sa := &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}
+	if err := unix.Bind(fd, sa); err != nil {
+		fmt.Fprintf(os.Stderr, "bind(vsock:%d): %v\n", port, err)
+		os.Exit(1)
+	}
+	if err := unix.Listen(fd, 8); err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("listening on vsock port %d\n", port)
+
+	for {
+		cfd, peer, err := unix.Accept(fd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "accept: %v\n", err)
+			os.Exit(1)
+		}
+		if vm, ok := peer.(*unix.SockaddrVM); ok {
+			fmt.Printf("accepted from cid=%d port=%d\n", vm.CID, vm.Port)
+		}
+		go func(fd int) {
+			f := os.NewFile(uintptr(fd), "vsock-conn")
+			defer f.Close()
+			f.WriteString("hawser-spike-c hello from the guest\n")
+			io.Copy(f, f) // echo until the host closes
+		}(cfd)
+	}
+}

--- a/spike/c/guest/main_other.go
+++ b/spike/c/guest/main_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+// Keeps `go build ./...` working in CI (windows runner); the listener itself
+// is linux-only.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "spike c guest is linux-only; build with GOOS=linux")
+	os.Exit(2)
+}

--- a/spike/c/host/go.mod
+++ b/spike/c/host/go.mod
@@ -1,0 +1,8 @@
+module github.com/zcsizmadia/hawser/spike/c/host
+
+go 1.23
+
+require (
+	github.com/Microsoft/go-winio v0.6.2
+	golang.org/x/sys v0.30.0
+)

--- a/spike/c/host/go.sum
+++ b/spike/c/host/go.sum
@@ -1,0 +1,4 @@
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/spike/c/host/main.go
+++ b/spike/c/host/main.go
@@ -1,0 +1,129 @@
+//go:build windows
+
+// Spike C host: dial AF_HYPERV from Windows into the WSL2 utility VM.
+//
+// The one genuinely uncertain step of #40 is discovering the utility VM's
+// GUID without elevation (hcsdiag list refuses non-admin). Probed answer: the
+// Host Compute Service mirrors running compute systems into
+// HKLM\...\HostComputeService\VolatileStore\ComputeSystem, and that key is
+// readable by standard users. Everything after that is known art: the
+// service ID is the vsock port templated into Microsoft's wildcard GUID
+// (go-winio's VsockServiceID), and WSLg ships on exactly this transport.
+//
+// Usage: host.exe [-vm GUID] [-port 5000] [-n 50]
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"golang.org/x/sys/windows/registry"
+)
+
+const computeSystemKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\HostComputeService\VolatileStore\ComputeSystem`
+
+// discoverVMs lists running compute-system GUIDs without elevation.
+func discoverVMs() ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, computeSystemKey, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return nil, fmt.Errorf("opening HCS VolatileStore (is any WSL distro running?): %w", err)
+	}
+	defer k.Close()
+	return k.ReadSubKeyNames(-1)
+}
+
+func dialOnce(vmid guid.GUID, port uint32, timeout time.Duration) (banner string, connectCost time.Duration, err error) {
+	addr := &winio.HvsockAddr{VMID: vmid, ServiceID: winio.VsockServiceID(port)}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := winio.Dial(ctx, addr)
+	if err != nil {
+		return "", 0, err
+	}
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	conn.SetReadDeadline(time.Now().Add(timeout))
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", 0, fmt.Errorf("reading banner: %w", err)
+	}
+	connectCost = time.Since(start)
+
+	// Echo round-trip proves both directions carry data.
+	if _, err := conn.Write([]byte("ping\n")); err != nil {
+		return "", 0, fmt.Errorf("write: %w", err)
+	}
+	echo, err := r.ReadString('\n')
+	if err != nil || echo != "ping\n" {
+		return "", 0, fmt.Errorf("echo round-trip failed: %q, %v", echo, err)
+	}
+	return strings.TrimSpace(line), connectCost, nil
+}
+
+func main() {
+	var (
+		vmFlag  = flag.String("vm", "", "VM GUID (default: discover from the HCS registry mirror)")
+		port    = flag.Uint("port", 5000, "vsock port the guest listens on")
+		n       = flag.Int("n", 50, "connections for the per-connection latency measurement")
+		timeout = flag.Duration("timeout", 5*time.Second, "per-dial timeout")
+	)
+	flag.Parse()
+
+	var candidates []string
+	if *vmFlag != "" {
+		candidates = []string{*vmFlag}
+	} else {
+		var err error
+		candidates, err = discoverVMs()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("discovered %d compute system(s) without elevation: %v\n", len(candidates), candidates)
+	}
+
+	for _, c := range candidates {
+		vmid, err := guid.FromString(c)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping %q: %v\n", c, err)
+			continue
+		}
+		banner, first, err := dialOnce(vmid, uint32(*port), *timeout)
+		if err != nil {
+			fmt.Printf("vm %s: no listener on vsock:%d (%v)\n", c, *port, err)
+			continue
+		}
+		fmt.Printf("vm %s: CONNECTED, banner=%q, first connect+banner=%v\n", c, banner, first)
+
+		// Per-connection cost: this is the number that replaces socat's
+		// ~165 ms measured in Spike A.
+		var total time.Duration
+		ok := 0
+		for i := 0; i < *n; i++ {
+			_, d, err := dialOnce(vmid, uint32(*port), *timeout)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  connection %d failed: %v\n", i, err)
+				continue
+			}
+			total += d
+			ok++
+		}
+		if ok > 0 {
+			fmt.Printf("per-connection cost over %d dials: avg %v\n", ok, total/time.Duration(ok))
+		}
+		fmt.Println("PASS")
+		return
+	}
+	fmt.Fprintln(os.Stderr, "FAIL: no candidate VM accepted the connection")
+	os.Exit(1)
+}

--- a/spike/c/run.ps1
+++ b/spike/c/run.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 5.1
+# Spike C end-to-end: build guest+host, run the probe, clean up.
+param(
+    [string]$Distro = 'Ubuntu',
+    [int]$Port = 5000,
+    [int]$Dials = 50
+)
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$work = Join-Path $env:TEMP "hawser-spike-c"
+New-Item -ItemType Directory -Force $work | Out-Null
+
+Write-Host "== building guest (linux/amd64) and host probes"
+Push-Location (Join-Path $here 'guest')
+$env:GOOS = 'linux'; $env:GOARCH = 'amd64'
+go build -o (Join-Path $work 'spikec-guest') .
+if ($LASTEXITCODE -ne 0) { exit 1 }
+Remove-Item Env:GOOS, Env:GOARCH
+Pop-Location
+Push-Location (Join-Path $here 'host')
+go build -o (Join-Path $work 'spikec-host.exe') .
+if ($LASTEXITCODE -ne 0) { exit 1 }
+Pop-Location
+
+Write-Host "== starting listener in $Distro on vsock:$Port"
+$guestPath = (wsl -d $Distro -- wslpath -u (($work -replace '\','/') + '/spikec-guest')).Trim()
+wsl -d $Distro -- sh -c "cp '$guestPath' /tmp/spikec-guest && chmod +x /tmp/spikec-guest && nohup /tmp/spikec-guest $Port > /tmp/spikec-guest.log 2>&1 & sleep 1; cat /tmp/spikec-guest.log"
+
+try {
+    Write-Host "== dialing from the host"
+    & (Join-Path $work 'spikec-host.exe') -port $Port -n $Dials
+    $result = $LASTEXITCODE
+} finally {
+    Write-Host "== cleaning up"
+    wsl -d $Distro -- sh -c 'kill $(pgrep -x spikec-guest) 2>/dev/null; rm -f /tmp/spikec-guest /tmp/spikec-guest.log' | Out-Null
+    Remove-Item -Recurse -Force $work
+}
+exit $result


### PR DESCRIPTION
The mini-spike gating #40 (vsock guest agent), run live on this machine as a **standard non-admin user** with Docker Desktop''s distro sharing the utility VM. Verdict: **GO**, every open question answered.

## Measured results

```
discovered 1 compute system(s) without elevation: [EAAC9D05-…]
vm EAAC9D05-…: CONNECTED, banner="hawser-spike-c hello from the guest", first connect+banner=4.005ms
per-connection cost over 50 dials: avg 574.456µs
PASS
```

## Findings

1. **VM-GUID discovery needs no elevation** — the HCS `VolatileStore\ComputeSystem` registry mirror is readable by standard users; `hcsdiag list` (Hyper-V-admin-only) is not needed.
2. **The dial is unprivileged** — go-winio `Dial(HvsockAddr{VMID, VsockServiceID(port)})`; no `GuestCommunicationServices` registration in the host→guest direction.
3. **Guest side is plain AF_VSOCK** — bind `VMADDR_CID_ANY`; `/dev/vsock` exists in stock WSL2 distros.
4. **Host arrives as CID 2** — the real agent can and should reject non-host peers.
5. **~0.6 ms per connection** vs socat''s ~165 ms from Spike A: the #40 latency target ("within 2× Docker Desktop") is cleared by two orders of magnitude, and #35''s leak class disappears once we own both ends.

## Kit

`spike/c/`: `guest/` AF_VSOCK echo listener (the exact socket code the real agent will use, plus a non-linux stub so CI''s windows runner can build the module), `host/` discovery + dial + latency probe, `run.ps1` end-to-end runner, README with the full findings.

Refs #40, #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)