### PR TITLE
vsock guest agent (hawser-agent): rootfs + engine-start wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spike/a/dl/
 go.work
 go.work.sum
 engine-bin/
+/agent

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/zcsizmadia/hawser
 go 1.23
 
 require (
-	github.com/Microsoft/go-winio v0.6.2 // indirect
-	golang.org/x/sys v0.10.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2
+	golang.org/x/sys v0.10.0
 )

--- a/guest/agent/conn.go
+++ b/guest/agent/conn.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// vsockConn wraps an accepted AF_VSOCK fd as an io.ReadWriteCloser with
+// CloseWrite, which vsockproto.Relay uses to propagate EOFs. The fd is put in
+// non-blocking mode before os.NewFile so reads park in Go's poller instead of
+// pinning an OS thread each.
+type vsockConn struct {
+	f  *os.File
+	fd int
+}
+
+func newVsockConn(fd int) (*vsockConn, error) {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return nil, err
+	}
+	return &vsockConn{f: os.NewFile(uintptr(fd), "vsock"), fd: fd}, nil
+}
+
+func (c *vsockConn) Read(p []byte) (int, error)  { return c.f.Read(p) }
+func (c *vsockConn) Write(p []byte) (int, error) { return c.f.Write(p) }
+func (c *vsockConn) Close() error                { return c.f.Close() }
+
+// CloseWrite sends EOF to the peer while reads keep working.
+func (c *vsockConn) CloseWrite() error {
+	return unix.Shutdown(c.fd, unix.SHUT_WR)
+}

--- a/guest/agent/main.go
+++ b/guest/agent/main.go
@@ -1,0 +1,115 @@
+//go:build linux
+
+// hawser-agent runs inside the engine distro and relays vsock connections
+// from the Windows host to dockerd's unix socket (#40).
+//
+// It replaces the per-connection `wsl.exe socat` path: owning both ends of
+// the transport gives explicit EOFs in both directions (shutdown(SHUT_WR) is
+// propagated by the relay), which is the complete fix for the connection
+// leak class of #35 — socat could not tell a Ctrl-C'd CLI from a build
+// upload's half-close.
+//
+// Security posture: only the host partition (CID 2) is allowed to connect,
+// and every connection must open with the vsockproto handshake before a
+// single byte reaches dockerd. Other distros in the shared utility VM (a
+// vsock port space they can reach) get a closed connection and no banner.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+
+	"github.com/zcsizmadia/hawser/internal/vsockproto"
+	"golang.org/x/sys/unix"
+)
+
+// Identity is what the handshake reports; the host logs it and future
+// versions can gate features on it.
+const Identity = "hawser-agent/1"
+
+func main() {
+	var (
+		version = flag.Bool("version", false, "print the agent identity and exit")
+		port    = flag.Uint("port", uint(vsockproto.Port), "vsock port to listen on")
+		socket  = flag.String("socket", "/var/run/docker.sock", "engine socket to relay to")
+	)
+	flag.Parse()
+	if *version {
+		fmt.Println(Identity)
+		return
+	}
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	if err := run(uint32(*port), *socket); err != nil {
+		log.Fatalf("hawser-agent: %v", err)
+	}
+}
+
+func run(port uint32, socket string) error {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("socket(AF_VSOCK): %w", err)
+	}
+	if err := unix.Bind(fd, &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}); err != nil {
+		return fmt.Errorf("bind(vsock:%d): %w", port, err)
+	}
+	if err := unix.Listen(fd, 32); err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	log.Printf("%s listening on vsock port %d, relaying to %s", Identity, port, socket)
+
+	for {
+		cfd, peer, err := unix.Accept4(fd, unix.SOCK_CLOEXEC)
+		if err != nil {
+			if err == unix.EINTR || err == unix.ECONNABORTED {
+				continue
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		vm, ok := peer.(*unix.SockaddrVM)
+		if !ok || vm.CID != vsockHostCID {
+			log.Printf("rejected connection from non-host peer %+v", peer)
+			unix.Close(cfd)
+			continue
+		}
+		conn, err := newVsockConn(cfd)
+		if err != nil {
+			log.Printf("wrapping connection: %v", err)
+			unix.Close(cfd)
+			continue
+		}
+		go serve(conn, socket)
+	}
+}
+
+// vsockHostCID is VMADDR_CID_HOST: the Windows host partition.
+const vsockHostCID = 2
+
+func serve(conn *vsockConn, socket string) {
+	defer conn.Close()
+
+	if err := vsockproto.ServerHandshake(conn, Identity); err != nil {
+		log.Printf("handshake refused: %v", err)
+		return
+	}
+	backend, err := net.Dial("unix", socket)
+	if err != nil {
+		log.Printf("dialing %s: %v", socket, err)
+		return
+	}
+	if err := vsockproto.Relay(conn, backend.(*net.UnixConn)); err != nil && !ignorable(err) {
+		log.Printf("relay: %v", err)
+	}
+}
+
+// ignorable filters the errors every teardown race produces.
+func ignorable(err error) bool {
+	return errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, unix.EPIPE) || errors.Is(err, unix.ECONNRESET) ||
+		errors.Is(err, os.ErrClosed)
+}

--- a/guest/agent/main_other.go
+++ b/guest/agent/main_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+// Keeps `go build ./...` green on the Windows CI runner and dev machines; the
+// agent itself only makes sense inside the distro.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "hawser-agent runs inside the engine distro; build with GOOS=linux")
+	os.Exit(2)
+}

--- a/guest/rootfs/assemble.Dockerfile
+++ b/guest/rootfs/assemble.Dockerfile
@@ -50,4 +50,5 @@ COPY wsl.conf /etc/wsl.conf
 # when no version is given, and `commits` is the provenance record a security
 # review reads.
 COPY engine-version /etc/hawser/engine-version
+COPY agent-version /etc/hawser/agent-version
 COPY commits /etc/hawser/commits

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -60,13 +60,34 @@ if [ ! -x "$engine/bin/dockerd" ]; then
       "golang:${GO_VERSION}-alpine" sh /build-engine.sh
 fi
 
+echo "==> building hawser-agent from this repo"
+# The vsock agent (#40) is the one binary in the rootfs that comes from this
+# repository rather than an upstream tag, so it is versioned by the rootfs
+# release itself. Built in the same pinned toolchain image as the engine, but
+# outside the BIN_DIR cache: it changes with this repo, not with versions.env.
+repo_root="$(cd "$here/../.." && pwd)"
+agent_out="$work/agent"
+mkdir -p "$agent_out"
+docker run --rm \
+  -v "$repo_root:/src:ro" \
+  -v "$agent_out:/out" \
+  -w /src \
+  -e CGO_ENABLED=0 \
+  "golang:${GO_VERSION}-alpine" \
+  sh -c "go build -trimpath -ldflags '-s -w' -o /out/hawser-agent ./guest/agent \
+         && chown $(id -u):$(id -g) /out/hawser-agent"
+
 echo "==> assembling rootfs"
 # Everything the image needs, staged as a build context.
 ctx="$work/ctx"
 mkdir -p "$ctx/bin"
 cp "$engine/bin/"* "$ctx/bin/"
+cp "$agent_out/hawser-agent" "$ctx/bin/"
 cp "$engine/commits.txt" "$ctx/commits"
 printf '%s\n' "$ENGINE_VERSION" > "$ctx/engine-version"
+# The agent states its own identity (static linux binary, runnable right
+# here); asking it beats duplicating the constant in shell.
+"$agent_out/hawser-agent" -version > "$ctx/agent-version"
 
 cat > "$ctx/daemon.json" <<'JSON'
 {

--- a/guest/rootfs/smoke-test.sh
+++ b/guest/rootfs/smoke-test.sh
@@ -31,8 +31,9 @@ echo "==> expected files"
 # userland-proxy is enabled, and `dockerd --validate` does not catch that - the
 # first rootfs release imported fine and then failed at startup.
 for f in usr/local/bin/dockerd usr/local/bin/docker-proxy usr/local/bin/containerd \
-         usr/local/bin/runc usr/local/bin/buildkitd etc/docker/daemon.json etc/wsl.conf \
-         etc/hawser/engine-version etc/hawser/commits; do
+         usr/local/bin/runc usr/local/bin/buildkitd usr/local/bin/hawser-agent \
+         etc/docker/daemon.json etc/wsl.conf \
+         etc/hawser/engine-version etc/hawser/agent-version etc/hawser/commits; do
     test -e "$work/$f" || { echo "missing $f"; exit 1; }
     echo "  ok $f"
 done
@@ -65,6 +66,11 @@ echo "==> binaries execute and report the pinned versions"
 "$work/usr/local/bin/buildkitd" --version
 "$work/usr/local/bin/buildkitd" --version | grep -q "${BUILDKIT_VERSION#v}" \
     || { echo "buildkitd version does not match $BUILDKIT_VERSION"; exit 1; }
+
+echo "==> hawser-agent identity matches what the rootfs declares"
+"$work/usr/local/bin/hawser-agent" -version
+test "$("$work/usr/local/bin/hawser-agent" -version)" = "$(cat "$work/etc/hawser/agent-version")" \
+    || { echo "agent-version file does not match the binary"; exit 1; }
 
 echo "==> provenance: one pinned commit per component"
 cat "$work/etc/hawser/commits"

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -217,6 +217,10 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 
 	if running, _ := p.engineRunning(ctx, opts); running {
 		p.logger().Info("engine already running", "distro", opts.Distro)
+		// The agent's lifetime is not tied to dockerd's: a supervisor that
+		// finds a healthy engine (its own restart, say) must still make sure
+		// the vsock path is up.
+		p.startAgent(ctx, opts)
 		return nil
 	}
 
@@ -227,6 +231,7 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 		"sh", "-c", "dockerd >>/var/log/dockerd.log 2>&1"); err != nil {
 		return fmt.Errorf("launching dockerd: %w", err)
 	}
+	p.startAgent(ctx, opts)
 
 	deadline := time.Now().Add(opts.StartTimeout)
 	for time.Now().Before(deadline) {
@@ -245,6 +250,21 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 	log, _ := p.wsl().Exec(ctx, opts.Distro, "root", "tail", "-30", "/var/log/dockerd.log")
 	return fmt.Errorf("dockerd did not create %s within %s. Last log lines:\n%s",
 		EngineSocket, opts.StartTimeout, log)
+}
+
+// agentStartCmd is what launches hawser-agent (#40), guarded three ways: a
+// rootfs that predates the agent has nothing to start (the socat relay stays
+// the transport), an agent already running must not be doubled, and `exec`
+// keeps the process tree flat. Never fatal by design — the engine is fully
+// usable without the vsock path.
+const agentStartCmd = "command -v hawser-agent >/dev/null 2>&1 || exit 0; " +
+	"pgrep -x hawser-agent >/dev/null 2>&1 && exit 0; " +
+	"exec hawser-agent >>/var/log/hawser-agent.log 2>&1"
+
+func (p *Provisioner) startAgent(ctx context.Context, opts Options) {
+	if _, err := p.wsl().Start(ctx, opts.Distro, "root", "sh", "-c", agentStartCmd); err != nil {
+		p.logger().Debug("hawser-agent not started", "error", err)
+	}
 }
 
 func (p *Provisioner) engineRunning(ctx context.Context, opts Options) (bool, error) {

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -137,6 +137,17 @@ func healthyWSL() *fakeWSL {
 	return &fakeWSL{status: wsl.Status{Installed: true, DefaultVersion: 2, Version: "2.7.8.0"}}
 }
 
+// startedMatching counts fake-started commands whose joined argv contains s.
+func startedMatching(w *fakeWSL, s string) int {
+	n := 0
+	for _, args := range w.started {
+		if strings.Contains(strings.Join(args, " "), s) {
+			n++
+		}
+	}
+	return n
+}
+
 // rootfsServer serves a payload and returns its URL and SHA-256.
 func rootfsServer(t *testing.T, payload []byte) (url, sum string) {
 	t.Helper()
@@ -185,8 +196,13 @@ func TestInstallHappyPath(t *testing.T) {
 	if _, err := os.Stat(w.imported[0][2]); err != nil {
 		t.Errorf("rootfs not on disk at import time: %v", err)
 	}
-	if len(w.started) != 1 {
-		t.Errorf("started %d commands, want 1 (dockerd)", len(w.started))
+	if n := startedMatching(w, "dockerd"); n != 1 {
+		t.Errorf("dockerd started %d times, want 1", n)
+	}
+	// The vsock agent (#40) rides along with every engine start; its command
+	// carries its own "not in this rootfs" and "already running" guards.
+	if n := startedMatching(w, "hawser-agent"); n != 1 {
+		t.Errorf("hawser-agent started %d times, want 1", n)
 	}
 
 	if m.EngineVersion != "29.7.2" || m.WSLVersion != "2.7.8.0" {
@@ -373,8 +389,8 @@ func TestStartEngineWaitsForSocket(t *testing.T) {
 	if err := p.StartEngine(context.Background(), opts); err != nil {
 		t.Fatalf("StartEngine: %v", err)
 	}
-	if len(w.started) != 1 {
-		t.Errorf("started %d commands, want 1", len(w.started))
+	if n := startedMatching(w, "dockerd"); n != 1 {
+		t.Errorf("dockerd started %d times, want 1", n)
 	}
 }
 
@@ -387,8 +403,13 @@ func TestStartEngineSkipsWhenAlreadyRunning(t *testing.T) {
 	if err := p.StartEngine(context.Background(), opts); err != nil {
 		t.Fatalf("StartEngine: %v", err)
 	}
-	if len(w.started) != 0 {
+	if n := startedMatching(w, "dockerd"); n != 0 {
 		t.Errorf("dockerd was launched even though the socket was already up")
+	}
+	// But the agent must still be ensured: a restarted supervisor finding a
+	// healthy engine cannot assume the vsock path is up.
+	if n := startedMatching(w, "hawser-agent"); n != 1 {
+		t.Errorf("hawser-agent ensured %d times, want 1", n)
 	}
 }
 

--- a/internal/vsockproto/proto.go
+++ b/internal/vsockproto/proto.go
@@ -1,0 +1,78 @@
+// Package vsockproto is the tiny wire protocol between the Windows host and
+// the in-distro hawser-agent (#40), shared by both ends.
+//
+// The connection starts line-oriented — client sends a magic hello, the agent
+// answers with its identity — and then goes fully transparent, a byte relay to
+// the engine socket. The handshake exists because the WSL2 utility VM's vsock
+// port space is shared by every distro in it (Docker Desktop's included): a
+// dial that reaches the wrong listener must fail closed, not speak Docker HTTP
+// at a stranger.
+package vsockproto
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Port is the vsock port the agent listens on: ASCII "haws". Vsock ports are
+// a full 32-bit space with no well-known registry, so an implausible value is
+// the collision strategy.
+const Port uint32 = 0x68617773
+
+const (
+	hello    = "HAWSER/1\n"
+	okPrefix = "OK "
+	// maxLine bounds handshake reads; anything longer is not our peer.
+	maxLine = 256
+)
+
+// readLine reads up to and including '\n' one byte at a time. Byte-wise on
+// purpose: a buffered reader could swallow bytes that belong to the
+// transparent phase that follows.
+func readLine(r io.Reader) (string, error) {
+	var b strings.Builder
+	buf := make([]byte, 1)
+	for b.Len() < maxLine {
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return "", err
+		}
+		if buf[0] == '\n' {
+			return b.String(), nil
+		}
+		b.WriteByte(buf[0])
+	}
+	return "", fmt.Errorf("handshake line exceeds %d bytes", maxLine)
+}
+
+// ServerHandshake validates the client hello and replies with this agent's
+// identity. On a bad hello the error is returned without a reply: the caller
+// closes, and the stranger learns nothing.
+func ServerHandshake(c io.ReadWriter, version string) error {
+	line, err := readLine(c)
+	if err != nil {
+		return fmt.Errorf("reading hello: %w", err)
+	}
+	if line+"\n" != hello {
+		return fmt.Errorf("unexpected hello %q", line)
+	}
+	if _, err := c.Write([]byte(okPrefix + version + "\n")); err != nil {
+		return fmt.Errorf("writing banner: %w", err)
+	}
+	return nil
+}
+
+// ClientHandshake sends the hello and returns the agent's identity line.
+func ClientHandshake(c io.ReadWriter) (string, error) {
+	if _, err := c.Write([]byte(hello)); err != nil {
+		return "", fmt.Errorf("writing hello: %w", err)
+	}
+	line, err := readLine(c)
+	if err != nil {
+		return "", fmt.Errorf("reading banner: %w", err)
+	}
+	if !strings.HasPrefix(line, okPrefix) {
+		return "", fmt.Errorf("peer is not a hawser agent: %q", line)
+	}
+	return strings.TrimPrefix(line, okPrefix), nil
+}

--- a/internal/vsockproto/proto_test.go
+++ b/internal/vsockproto/proto_test.go
@@ -1,0 +1,192 @@
+package vsockproto
+
+import (
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandshakeRoundTrip(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- ServerHandshake(server, "hawser-agent/1") }()
+
+	got, err := ClientHandshake(client)
+	if err != nil {
+		t.Fatalf("ClientHandshake: %v", err)
+	}
+	if got != "hawser-agent/1" {
+		t.Errorf("agent identity = %q, want hawser-agent/1", got)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("ServerHandshake: %v", err)
+	}
+}
+
+func TestServerRejectsStrangerSilently(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- ServerHandshake(server, "v") }()
+
+	// A Docker HTTP request head, i.e. what would arrive if a client skipped
+	// the handshake or the wrong service was dialed.
+	go client.Write([]byte("GET /_ping HTTP/1.1\n"))
+	if err := <-done; err == nil {
+		t.Fatal("ServerHandshake accepted a non-hawser hello")
+	}
+
+	// And nothing was written back: the stranger learns nothing.
+	client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buf := make([]byte, 1)
+	if n, _ := client.Read(buf); n != 0 {
+		t.Errorf("server replied %q to a stranger", buf[:n])
+	}
+}
+
+func TestClientRejectsNonAgentPeer(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		io.ReadFull(server, make([]byte, len("HAWSER/1\n")))
+		server.Write([]byte("HTTP/1.1 400 Bad Request\n"))
+	}()
+	if _, err := ClientHandshake(client); err == nil {
+		t.Fatal("ClientHandshake accepted a non-agent banner")
+	}
+}
+
+func TestHandshakeDoesNotEatTransparentBytes(t *testing.T) {
+	// The byte after the banner's newline belongs to the relay phase; a
+	// buffered handshake reader would swallow it.
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		ServerHandshake(server, "v1")
+		server.Write([]byte("payload"))
+	}()
+
+	if _, err := ClientHandshake(client); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 7)
+	client.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := io.ReadFull(client, buf); err != nil {
+		t.Fatalf("reading post-handshake payload: %v", err)
+	}
+	if string(buf) != "payload" {
+		t.Errorf("post-handshake bytes = %q, want payload", buf)
+	}
+}
+
+func TestHandshakeLineBounded(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- ServerHandshake(server, "v") }()
+	go client.Write([]byte(strings.Repeat("A", 4096)))
+	if err := <-done; err == nil {
+		t.Fatal("unbounded handshake line accepted")
+	}
+}
+
+// tcpPair returns two connected TCP conns, which support CloseWrite on every
+// platform — the same half-close shape as vsock and unix sockets.
+func tcpPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	ch := make(chan net.Conn, 1)
+	go func() {
+		c, err := l.Accept()
+		if err == nil {
+			ch <- c
+		}
+	}()
+	c1, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2 := <-ch
+	t.Cleanup(func() { c1.Close(); c2.Close() })
+	return c1, c2
+}
+
+func TestRelayPropagatesHalfClose(t *testing.T) {
+	// client <-> (relay) <-> backend. The client half-closes after its
+	// request; the backend must see EOF, and its response must still flow —
+	// exactly the docker-build shape that socat could not distinguish from a
+	// disconnect.
+	clientSide, relayLeft := tcpPair(t)
+	relayRight, backendSide := tcpPair(t)
+
+	relayDone := make(chan error, 1)
+	go func() { relayDone <- Relay(relayLeft, relayRight) }()
+
+	// Backend: read everything (until EOF), then respond, then close.
+	backendDone := make(chan string, 1)
+	go func() {
+		req, _ := io.ReadAll(backendSide)
+		backendSide.Write([]byte("response"))
+		backendSide.Close()
+		backendDone <- string(req)
+	}()
+
+	clientSide.Write([]byte("request"))
+	clientSide.(*net.TCPConn).CloseWrite()
+
+	resp, err := io.ReadAll(clientSide)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(resp) != "response" {
+		t.Errorf("client got %q, want response", resp)
+	}
+	if req := <-backendDone; req != "request" {
+		t.Errorf("backend got %q, want request", req)
+	}
+	if err := <-relayDone; err != nil {
+		t.Errorf("Relay returned %v", err)
+	}
+}
+
+func TestRelayFullClosesWithoutCloseWrite(t *testing.T) {
+	// net.Pipe has no CloseWrite; the relay must degrade to a full close
+	// rather than deadlock.
+	clientSide, relayLeft := net.Pipe()
+	relayRight, backendSide := net.Pipe()
+
+	relayDone := make(chan error, 1)
+	go func() { relayDone <- Relay(relayLeft, relayRight) }()
+
+	go func() {
+		buf := make([]byte, 3)
+		io.ReadFull(backendSide, buf)
+		backendSide.Close()
+	}()
+
+	clientSide.Write([]byte("hey"))
+	clientSide.Close()
+
+	select {
+	case <-relayDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Relay deadlocked on a transport without CloseWrite")
+	}
+}

--- a/internal/vsockproto/relay.go
+++ b/internal/vsockproto/relay.go
@@ -1,0 +1,57 @@
+package vsockproto
+
+import (
+	"io"
+	"sync"
+)
+
+// WriteCloser is the half-close half of the story. Both vsock and unix
+// sockets support shutdown(SHUT_WR), and propagating it is what makes a
+// client's EOF explicit instead of inferred — the property socat lacked and
+// the reason #35 could only be bounded, not fixed.
+type WriteCloser interface {
+	CloseWrite() error
+}
+
+// closeWrite half-closes when the conn supports it, else fully closes —
+// the degraded-but-correct behavior for transports without shutdown.
+func closeWrite(c io.Closer) {
+	if hc, ok := c.(WriteCloser); ok {
+		hc.CloseWrite()
+		return
+	}
+	c.Close()
+}
+
+// Relay copies bytes both ways, propagating each side's EOF to the other as a
+// write-shutdown, and returns when both directions are done. Errors other
+// than the usual close-races are reported from the first direction to fail.
+func Relay(a, b io.ReadWriteCloser) error {
+	var wg sync.WaitGroup
+	var once sync.Once
+	var firstErr error
+
+	cp := func(dst, src io.ReadWriteCloser) {
+		defer wg.Done()
+		_, err := io.Copy(dst, src)
+		if err != nil {
+			once.Do(func() { firstErr = err })
+			// A broken direction cannot half-close its way out; tear down.
+			dst.Close()
+			src.Close()
+			return
+		}
+		// src reached EOF: tell dst's reader there is nothing more coming,
+		// while dst→src traffic keeps flowing.
+		closeWrite(dst)
+	}
+
+	wg.Add(2)
+	go cp(a, b)
+	go cp(b, a)
+	wg.Wait()
+
+	a.Close()
+	b.Close()
+	return firstErr
+}


### PR DESCRIPTION
First implementation slice of #40, building on Spike C''s GO (#50).

## What

- **`internal/vsockproto`** — the tiny shared protocol, used by the agent now and the host dialer in the next PR:
  - Port `0x68617773` ("haws"): the utility VM''s vsock port space is shared by every distro in it (Docker Desktop''s included), so the port is collision-implausible and a line handshake (`HAWSER/1` → `OK <identity>`) makes wrong-peer dials fail closed. Handshake reads are byte-wise so no relay bytes get swallowed; refused strangers get no banner.
  - `Relay` propagates **half-closes** (`shutdown(SHUT_WR)`) in both directions, degrading to full close for transports without `CloseWrite`. This is the property socat lacked and the reason #35 could only be bounded.
- **`guest/agent`** — `hawser-agent`, in the main module (linux build tag + CI stub): AF_VSOCK listener accepting only **CID 2** (the host partition), handshake, then relay to `/var/run/docker.sock`. `-version` prints the identity.
- **Rootfs pipeline** — `build.sh` compiles the agent from this repo in the pinned golang image (outside the engine-bin cache: it changes with this repo, not `versions.env`) and records the binary''s self-reported identity as `/etc/hawser/agent-version`; smoke test asserts presence, executability, and identity match.
- **Provisioner** — `StartEngine` launches the agent with dockerd and also ensures it when the engine is already running (a restarted supervisor cannot assume the vsock path is up). The launch command guards itself: agent-less rootfs → quiet no-op (socat stays the transport); already-running agent → not doubled.

## Verified live (not just unit tests)

Agent running in a WSL2 distro, probe from Windows via go-winio hvsock: handshake returned `hawser-agent/1`, and a `CloseWrite` on the Windows side arrived at a unix-socket backend as a genuine EOF **with the response still flowing back afterward** — the exact docker-build shape socat couldn''t distinguish from a disconnect.

Unit: 11 packages green, incl. handshake stranger-rejection, transparent-byte preservation, half-close propagation and no-CloseWrite degradation.

Next PR: host-side vsock dialer with automatic socat fallback, then a rootfs release + manifest bump.

Refs #40, #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)