### PR TITLE
Host vsock dialer with automatic socat fallback

### DIFF
--- a/cmd/hawser/dialer.go
+++ b/cmd/hawser/dialer.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+)
+
+// engineDialer builds the transport to the engine socket: the vsock agent
+// (#40) first, the socat relay as automatic per-connection fallback — one
+// dialer serves a new rootfs with the agent, an old rootfs without it, and an
+// agent mid-restart, with no configuration.
+//
+// HAWSER_NO_VSOCK=1 pins the socat path, as the support lever for a machine
+// where the fast path misbehaves.
+func engineDialer(distro, socketPath string, log *slog.Logger) pipeproxy.Dialer {
+	socat := &pipeproxy.WSLDialer{Distro: distro, SocketPath: socketPath}
+	if os.Getenv("HAWSER_NO_VSOCK") == "1" {
+		log.Info("vsock transport disabled by HAWSER_NO_VSOCK")
+		return socat
+	}
+	return &pipeproxy.FallbackDialer{
+		Primary:   &pipeproxy.VsockDialer{},
+		Secondary: socat,
+		Logger:    log,
+	}
+}

--- a/cmd/hawser/proxy.go
+++ b/cmd/hawser/proxy.go
@@ -101,10 +101,7 @@ flags:
 	}
 
 	srv := &pipeproxy.Server{
-		Dialer: &pipeproxy.WSLDialer{
-			Distro:     targetDistro,
-			SocketPath: *socketPath,
-		},
+		Dialer: engineDialer(targetDistro, *socketPath, log),
 		Logger: log,
 	}
 	if !*noRewrite {

--- a/cmd/hawser/supervise.go
+++ b/cmd/hawser/supervise.go
@@ -136,7 +136,7 @@ flags:
 
 	// ...while the pipe server carries traffic. Both stop together.
 	srv := &pipeproxy.Server{
-		Dialer:  &pipeproxy.WSLDialer{Distro: targetDistro},
+		Dialer:  engineDialer(targetDistro, "", log),
 		Logger:  log,
 		Handler: pipeproxy.RewriteBinds,
 	}

--- a/internal/pipeproxy/dial_fallback.go
+++ b/internal/pipeproxy/dial_fallback.go
@@ -1,0 +1,44 @@
+package pipeproxy
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+)
+
+// FallbackDialer tries Primary on every connection and uses Secondary when it
+// fails. Built for the vsock→socat pairing: a rootfs that predates the agent,
+// an agent that died, or a VM mid-restart must degrade to the slow path, not
+// to an outage — and must return to the fast path by itself, so the primary
+// is re-attempted every time rather than latched off.
+//
+// Logging is edge-triggered: one line when the primary is first unavailable,
+// one when it recovers. Per-connection failure logs at that rate would be
+// noise on an agent-less rootfs, where failing is the expected steady state.
+type FallbackDialer struct {
+	Primary   Dialer
+	Secondary Dialer
+
+	// Logger receives the transition lines. Nil means silent.
+	Logger *slog.Logger
+
+	// degraded is 0 while the primary works, 1 while falling back.
+	degraded atomic.Bool
+}
+
+// Dial implements Dialer.
+func (d *FallbackDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	conn, err := d.Primary.Dial(ctx)
+	if err == nil {
+		if d.degraded.CompareAndSwap(true, false) && d.Logger != nil {
+			d.Logger.Info("engine transport recovered to the fast path")
+		}
+		return conn, nil
+	}
+	if d.degraded.CompareAndSwap(false, true) && d.Logger != nil {
+		d.Logger.Warn("engine fast path unavailable, using fallback transport",
+			"error", err)
+	}
+	return d.Secondary.Dial(ctx)
+}

--- a/internal/pipeproxy/dial_fallback_test.go
+++ b/internal/pipeproxy/dial_fallback_test.go
@@ -1,0 +1,101 @@
+package pipeproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+type stubConn struct{ io.ReadWriteCloser }
+
+func stubDialer(err error) (Dialer, *int) {
+	calls := new(int)
+	return DialerFunc(func(ctx context.Context) (io.ReadWriteCloser, error) {
+		*calls++
+		if err != nil {
+			return nil, err
+		}
+		return stubConn{}, nil
+	}), calls
+}
+
+func TestFallbackUsesPrimaryWhenHealthy(t *testing.T) {
+	primary, pCalls := stubDialer(nil)
+	secondary, sCalls := stubDialer(nil)
+	d := &FallbackDialer{Primary: primary, Secondary: secondary}
+
+	if _, err := d.Dial(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if *pCalls != 1 || *sCalls != 0 {
+		t.Errorf("primary=%d secondary=%d calls, want 1/0", *pCalls, *sCalls)
+	}
+}
+
+func TestFallbackDegradesAndRetriesPrimary(t *testing.T) {
+	primary, pCalls := stubDialer(errors.New("no agent"))
+	secondary, sCalls := stubDialer(nil)
+	d := &FallbackDialer{Primary: primary, Secondary: secondary}
+
+	for i := 0; i < 3; i++ {
+		if _, err := d.Dial(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The primary is re-attempted every connection — never latched off —
+	// so recovery needs no state reset.
+	if *pCalls != 3 || *sCalls != 3 {
+		t.Errorf("primary=%d secondary=%d calls, want 3/3", *pCalls, *sCalls)
+	}
+}
+
+func TestFallbackReportsSecondaryError(t *testing.T) {
+	primary, _ := stubDialer(errors.New("no agent"))
+	secondary, _ := stubDialer(errors.New("socat gone too"))
+	d := &FallbackDialer{Primary: primary, Secondary: secondary}
+
+	if _, err := d.Dial(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "socat gone too") {
+		t.Errorf("want the secondary's error surfaced, got %v", err)
+	}
+}
+
+func TestFallbackLogsEdgesNotEveryFailure(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+
+	fail := errors.New("no agent")
+	var primaryErr error = fail
+	primary := DialerFunc(func(ctx context.Context) (io.ReadWriteCloser, error) {
+		if primaryErr != nil {
+			return nil, primaryErr
+		}
+		return stubConn{}, nil
+	})
+	secondary, _ := stubDialer(nil)
+	d := &FallbackDialer{Primary: primary, Secondary: secondary, Logger: log}
+
+	for i := 0; i < 5; i++ {
+		d.Dial(context.Background())
+	}
+	if n := strings.Count(buf.String(), "fallback transport"); n != 1 {
+		t.Errorf("degradation logged %d times over 5 failures, want 1:\n%s", n, buf.String())
+	}
+
+	primaryErr = nil
+	d.Dial(context.Background())
+	if n := strings.Count(buf.String(), "recovered"); n != 1 {
+		t.Errorf("recovery logged %d times, want 1:\n%s", n, buf.String())
+	}
+
+	// A second outage is a new edge and logs again.
+	primaryErr = fail
+	d.Dial(context.Background())
+	if n := strings.Count(buf.String(), "fallback transport"); n != 2 {
+		t.Errorf("second degradation edge logged %d times total, want 2", n)
+	}
+}

--- a/internal/pipeproxy/dial_vsock_windows.go
+++ b/internal/pipeproxy/dial_vsock_windows.go
@@ -1,0 +1,137 @@
+//go:build windows
+
+package pipeproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/zcsizmadia/hawser/internal/vsockproto"
+	"golang.org/x/sys/windows/registry"
+)
+
+// VsockDialer reaches the engine through the in-distro hawser-agent over
+// AF_HYPERV — the v0.2 transport (#40), validated by Spike C. Per-connection
+// cost is ~0.6 ms against socat's ~165 ms, and both ends support half-close,
+// which removes the leak class of #35 outright.
+type VsockDialer struct {
+	// Port is the agent's vsock port. Zero uses vsockproto.Port.
+	Port uint32
+
+	// DialTimeout bounds one dial+handshake attempt. Zero uses 2s: the VM is
+	// local, so anything slower than that is a "not there", not a "be patient".
+	DialTimeout time.Duration
+
+	// mu guards vmid, the discovered-and-verified utility VM. Caching it
+	// skips registry enumeration on every connection; a dial failure clears
+	// it, so a restarted VM (new GUID) is re-discovered on the next attempt.
+	mu   sync.Mutex
+	vmid *guid.GUID
+}
+
+// computeSystemKey is the Host Compute Service's mirror of running compute
+// systems. Readable by standard users — the property Spike C established that
+// makes this transport possible without elevation (hcsdiag needs Hyper-V
+// admin). The key only lists *running* systems: with the distro stopped there
+// are no candidates, which correctly reads as "agent unreachable".
+const computeSystemKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\HostComputeService\VolatileStore\ComputeSystem`
+
+func discoverVMIDs() ([]guid.GUID, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, computeSystemKey, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return nil, fmt.Errorf("pipeproxy: enumerating compute systems: %w", err)
+	}
+	defer k.Close()
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("pipeproxy: reading compute systems: %w", err)
+	}
+	ids := make([]guid.GUID, 0, len(names))
+	for _, n := range names {
+		if id, err := guid.FromString(n); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+func (d *VsockDialer) port() uint32 {
+	if d.Port == 0 {
+		return vsockproto.Port
+	}
+	return d.Port
+}
+
+func (d *VsockDialer) timeout() time.Duration {
+	if d.DialTimeout == 0 {
+		return 2 * time.Second
+	}
+	return d.DialTimeout
+}
+
+// dialVM makes one verified connection: transport dial plus the vsockproto
+// handshake. The handshake is what turns "some listener answered on our port
+// in some VM" into "this is a hawser agent" — non-WSL utility VMs can appear
+// in the compute-system list, and the port space inside the WSL VM is shared
+// with every other distro.
+func (d *VsockDialer) dialVM(ctx context.Context, vmid guid.GUID) (io.ReadWriteCloser, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout())
+	defer cancel()
+	conn, err := winio.Dial(ctx, &winio.HvsockAddr{
+		VMID:      vmid,
+		ServiceID: winio.VsockServiceID(d.port()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	// The handshake shares the dial's deadline; clear it before handing the
+	// transparent stream to the relay.
+	conn.SetDeadline(time.Now().Add(d.timeout()))
+	if _, err := vsockproto.ClientHandshake(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	conn.SetDeadline(time.Time{})
+	return conn, nil
+}
+
+// Dial implements Dialer.
+func (d *VsockDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	d.mu.Lock()
+	cached := d.vmid
+	d.mu.Unlock()
+
+	if cached != nil {
+		if conn, err := d.dialVM(ctx, *cached); err == nil {
+			return conn, nil
+		}
+		// The VM may have restarted under a new GUID; fall through to a
+		// fresh discovery rather than failing on stale state.
+		d.mu.Lock()
+		d.vmid = nil
+		d.mu.Unlock()
+	}
+
+	ids, err := discoverVMIDs()
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error = fmt.Errorf("pipeproxy: no running compute systems")
+	for i := range ids {
+		conn, err := d.dialVM(ctx, ids[i])
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		d.mu.Lock()
+		d.vmid = &ids[i]
+		d.mu.Unlock()
+		return conn, nil
+	}
+	return nil, fmt.Errorf("pipeproxy: no hawser agent reachable: %w", lastErr)
+}

--- a/internal/pipeproxy/dial_vsock_windows.go
+++ b/internal/pipeproxy/dial_vsock_windows.go
@@ -4,6 +4,7 @@ package pipeproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -27,12 +28,27 @@ type VsockDialer struct {
 	// local, so anything slower than that is a "not there", not a "be patient".
 	DialTimeout time.Duration
 
-	// mu guards vmid, the discovered-and-verified utility VM. Caching it
-	// skips registry enumeration on every connection; a dial failure clears
-	// it, so a restarted VM (new GUID) is re-discovered on the next attempt.
-	mu   sync.Mutex
-	vmid *guid.GUID
+	// Cooldown is how long Dial fails instantly after a failed attempt,
+	// instead of probing again. Zero uses 15s; negative disables the cache.
+	// Without it, an agent-less rootfs would pay a full dial timeout on
+	// every connection while the fallback transport does the real work.
+	Cooldown time.Duration
+
+	// dialHV overrides the transport dial in tests.
+	dialHV func(ctx context.Context, vmid guid.GUID) (io.ReadWriteCloser, error)
+
+	// mu guards the discovery/failure cache. vmid is the verified utility VM,
+	// so registry enumeration is skipped per connection; a dial failure clears
+	// it (a restarted VM gets a new GUID) and stamps lastFailure.
+	mu          sync.Mutex
+	vmid        *guid.GUID
+	lastFailure time.Time
 }
+
+// ErrCoolingDown is returned while the dialer sits out its post-failure
+// cooldown. Callers with a fallback treat it like any dial error, just an
+// instant one.
+var ErrCoolingDown = errors.New("pipeproxy: vsock transport cooling down after a failure")
 
 // computeSystemKey is the Host Compute Service's mirror of running compute
 // systems. Readable by standard users — the property Spike C established that
@@ -74,38 +90,107 @@ func (d *VsockDialer) timeout() time.Duration {
 	return d.DialTimeout
 }
 
+// rawDial is the transport dial, a seam for tests. The production dial wraps
+// winio in a goroutine because winio's ConnectEx wait does not check the
+// context ("asyncIO doesn't check the context" — winio's own comment), and an
+// hv-socket connect to a port nobody listens on is not refused, it times out
+// at OS level after ~16s. Measured: an agent-less rootfs turned every docker
+// command into a 32s crawl. The goroutine is abandoned on timeout and closes
+// the connection if the OS ever completes it.
+func (d *VsockDialer) rawDial(ctx context.Context, vmid guid.GUID) (io.ReadWriteCloser, error) {
+	if d.dialHV != nil {
+		return d.dialHV(ctx, vmid)
+	}
+	type result struct {
+		conn *winio.HvsockConn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := winio.Dial(ctx, &winio.HvsockAddr{
+			VMID:      vmid,
+			ServiceID: winio.VsockServiceID(d.port()),
+		})
+		ch <- result{conn, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.conn, r.err
+	case <-time.After(d.timeout()):
+		go func() {
+			if r := <-ch; r.conn != nil {
+				r.conn.Close()
+			}
+		}()
+		return nil, fmt.Errorf("pipeproxy: vsock dial timed out after %s", d.timeout())
+	case <-ctx.Done():
+		go func() {
+			if r := <-ch; r.conn != nil {
+				r.conn.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	}
+}
+
 // dialVM makes one verified connection: transport dial plus the vsockproto
 // handshake. The handshake is what turns "some listener answered on our port
 // in some VM" into "this is a hawser agent" — non-WSL utility VMs can appear
 // in the compute-system list, and the port space inside the WSL VM is shared
 // with every other distro.
 func (d *VsockDialer) dialVM(ctx context.Context, vmid guid.GUID) (io.ReadWriteCloser, error) {
-	ctx, cancel := context.WithTimeout(ctx, d.timeout())
-	defer cancel()
-	conn, err := winio.Dial(ctx, &winio.HvsockAddr{
-		VMID:      vmid,
-		ServiceID: winio.VsockServiceID(d.port()),
-	})
+	conn, err := d.rawDial(ctx, vmid)
 	if err != nil {
 		return nil, err
 	}
-	// The handshake shares the dial's deadline; clear it before handing the
-	// transparent stream to the relay.
-	conn.SetDeadline(time.Now().Add(d.timeout()))
+	// The handshake gets its own deadline when the transport supports one;
+	// cleared before the transparent stream goes to the relay.
+	type deadliner interface{ SetDeadline(time.Time) error }
+	if dc, ok := conn.(deadliner); ok {
+		dc.SetDeadline(time.Now().Add(d.timeout()))
+		defer dc.SetDeadline(time.Time{})
+	}
 	if _, err := vsockproto.ClientHandshake(conn); err != nil {
 		conn.Close()
 		return nil, err
 	}
-	conn.SetDeadline(time.Time{})
 	return conn, nil
+}
+
+func (d *VsockDialer) cooldown() time.Duration {
+	switch {
+	case d.Cooldown < 0:
+		return 0
+	case d.Cooldown == 0:
+		return 15 * time.Second
+	default:
+		return d.Cooldown
+	}
 }
 
 // Dial implements Dialer.
 func (d *VsockDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
 	d.mu.Lock()
 	cached := d.vmid
+	coolingDown := !d.lastFailure.IsZero() && time.Since(d.lastFailure) < d.cooldown()
 	d.mu.Unlock()
 
+	if coolingDown {
+		return nil, ErrCoolingDown
+	}
+
+	conn, err := d.dialAny(ctx, cached)
+	d.mu.Lock()
+	if err != nil {
+		d.lastFailure = time.Now()
+	} else {
+		d.lastFailure = time.Time{}
+	}
+	d.mu.Unlock()
+	return conn, err
+}
+
+func (d *VsockDialer) dialAny(ctx context.Context, cached *guid.GUID) (io.ReadWriteCloser, error) {
 	if cached != nil {
 		if conn, err := d.dialVM(ctx, *cached); err == nil {
 			return conn, nil

--- a/internal/pipeproxy/dial_vsock_windows_test.go
+++ b/internal/pipeproxy/dial_vsock_windows_test.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package pipeproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+)
+
+// fakeHV lets tests script the transport without a VM.
+func fakeHV(d *VsockDialer, fn func() (io.ReadWriteCloser, error)) *int {
+	calls := new(int)
+	d.dialHV = func(ctx context.Context, vmid guid.GUID) (io.ReadWriteCloser, error) {
+		*calls++
+		return fn()
+	}
+	return calls
+}
+
+func TestVsockDialerCoolsDownAfterFailure(t *testing.T) {
+	d := &VsockDialer{Cooldown: time.Hour}
+	calls := fakeHV(d, func() (io.ReadWriteCloser, error) {
+		return nil, errors.New("no listener")
+	})
+
+	// First dial really probes (and fails; discovery may or may not find
+	// VMs on the test machine, both are failures).
+	if _, err := d.Dial(context.Background()); err == nil {
+		t.Fatal("dial succeeded with a failing transport")
+	}
+	probed := *calls
+
+	// While cooling down, dials fail instantly without touching the
+	// transport — this is what keeps an agent-less rootfs from paying a
+	// dial timeout per docker command.
+	for i := 0; i < 5; i++ {
+		_, err := d.Dial(context.Background())
+		if !errors.Is(err, ErrCoolingDown) {
+			t.Fatalf("dial %d during cooldown: err = %v, want ErrCoolingDown", i, err)
+		}
+	}
+	if *calls != probed {
+		t.Errorf("transport dialed %d times during cooldown", *calls-probed)
+	}
+}
+
+func TestVsockDialerRetriesAfterCooldown(t *testing.T) {
+	d := &VsockDialer{Cooldown: time.Millisecond}
+	fakeHV(d, func() (io.ReadWriteCloser, error) {
+		return nil, errors.New("no listener")
+	})
+
+	d.Dial(context.Background())
+	time.Sleep(5 * time.Millisecond)
+	if _, err := d.Dial(context.Background()); errors.Is(err, ErrCoolingDown) {
+		t.Fatal("still cooling down after the window passed")
+	}
+}
+
+func TestVsockDialerNegativeCooldownDisables(t *testing.T) {
+	d := &VsockDialer{Cooldown: -1}
+	fakeHV(d, func() (io.ReadWriteCloser, error) {
+		return nil, errors.New("no listener")
+	})
+
+	d.Dial(context.Background())
+	if _, err := d.Dial(context.Background()); errors.Is(err, ErrCoolingDown) {
+		t.Fatal("cooldown applied despite being disabled")
+	}
+}

--- a/internal/pipeproxy/listen_windows.go
+++ b/internal/pipeproxy/listen_windows.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
 
 // DefaultPipeName is what stock docker.exe connects to when DOCKER_HOST is
@@ -56,7 +57,12 @@ func Listen(pipeName, sddl string) (net.Listener, error) {
 }
 
 func init() {
-	// What a winio pipe returns when the relay closes its other direction —
-	// ordinary shutdown, not a fault worth logging.
-	platformClosedErrors = append(platformClosedErrors, winio.ErrFileClosed)
+	// Ordinary shutdown shapes on Windows, not faults worth logging:
+	// winio.ErrFileClosed is what a winio pipe returns when the relay closes
+	// its other direction; ERROR_BROKEN_PIPE ("the pipe has been ended") and
+	// ERROR_NO_DATA ("the pipe is being closed") are what a pipe or hvsock
+	// read/write returns when the peer went away abruptly — the normal end of
+	// a docker CLI that exits mid-connection.
+	platformClosedErrors = append(platformClosedErrors,
+		winio.ErrFileClosed, windows.ERROR_BROKEN_PIPE, windows.ERROR_NO_DATA)
 }

--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -160,11 +160,15 @@ func (s *Server) handle(ctx context.Context, client net.Conn) {
 		// it needs a thin adapter to fit the Handler signature.
 		handler = func(c net.Conn, e io.ReadWriteCloser) error { return Relay(c, e) }
 	}
-	if err := handler(client, engine); err != nil {
-		// Warn, not Debug: filterClosed has already dropped the ordinary ways a
-		// docker client hangs up, so anything left is a real fault the user
-		// wants to see. An engine that is down otherwise looks like the bridge
-		// doing nothing at all.
+	// filterClosed here as well as inside Relay: a handler like RewriteBinds
+	// returns transport errors from its own HTTP forwarding (wrapped with %w,
+	// so errors.Is still sees them), and a docker CLI exiting mid-response is
+	// ordinary shutdown regardless of which layer noticed it first.
+	if err := filterClosed(handler(client, engine)); err != nil {
+		// Warn, not Debug: the ordinary ways a docker client hangs up are
+		// filtered, so anything left is a real fault the user wants to see. An
+		// engine that is down otherwise looks like the bridge doing nothing at
+		// all.
 		log.Warn("connection failed", "error", err)
 	}
 }


### PR DESCRIPTION
Second slice of #40: the Windows side of the agent transport, with automatic degradation.

## What

- **`pipeproxy.VsockDialer`** — discovers the utility VM from the HCS VolatileStore registry mirror (standard-user readable, Spike C), dials AF_HYPERV via go-winio, runs the `vsockproto` handshake so a wrong listener fails closed before any Docker bytes flow. Verified VM ID cached per dialer, invalidated on failure (a restarted VM gets a new GUID).
- **`pipeproxy.FallbackDialer`** — vsock first on every connection (never latched off, so recovery is automatic), socat on failure; edge-triggered logging (one line on degradation, one on recovery).
- **`engineDialer`** helper wires both `hawser proxy` and the supervisor; `HAWSER_NO_VSOCK=1` pins the socat path as a support lever.

## Found and fixed by live-testing the degraded path

Against the published (agent-less) rootfs, every docker command initially took **32s**:
- winio''s ConnectEx wait ignores the context ("asyncIO doesn''t check the context" — winio''s own comment), and hv-socket connects to a listener-less port time out at OS level (~16s) instead of being refused. `rawDial` now bounds the dial itself (2s) and abandons the OS attempt.
- Even 2s/connection is a tax: a failed dial starts a **15s cooldown** during which the primary fails instantly (`ErrCoolingDown`), so the fallback steady state pays ~nothing.
- Abrupt docker-CLI exits surfaced as WARN noise ("the pipe has been ended/is being closed"); `ERROR_BROKEN_PIPE`/`ERROR_NO_DATA` join the closed-error filter, applied at the serve site too.

## Measured on this machine

| path | docker version |
|---|---|
| socat fallback (published rootfs) | ~150 ms |
| vsock (agent injected into the distro) | **~80 ms** |

Degradation → recovery verified live: agent killed → one degradation log line, traffic keeps flowing over socat; agent restarted → "recovered to the fast path" within the cooldown window. The supervisor''s `StartEngine` (from #51) relaunches the agent across engine restarts.

Unit: 11 packages green (new cooldown + fallback-edge tests). Acceptance: full 13-stage suite green (42s) against the published agent-less rootfs — the exact degraded mode users are in until the rootfs release ships.

Refs #40, #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)