### PR TITLE
Rootfs packaging revision (ENGINE_VERSION-REVISION artifacts)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,10 +18,17 @@ An app release embeds the rootfs checksum in
 [`internal/release/manifest.json`](internal/release/manifest.json). So the rootfs
 has to exist first:
 
-1. **Cut the rootfs release.** Tag `rootfs-v<engine-version>` — e.g.
-   `rootfs-v29.7.2`, matching `ENGINE_VERSION` in `guest/rootfs/versions.env`.
-   Publishing it triggers `rootfs.yml`, which rebuilds from source (or restores
-   the cached binaries), runs the smoke test, and attaches the three assets.
+1. **Cut the rootfs release.** Tag `rootfs-v<engine-version>-<revision>` —
+   e.g. `rootfs-v29.7.2-2`, matching `ENGINE_VERSION` and `ROOTFS_REVISION` in
+   `guest/rootfs/versions.env`. The revision exists because the tarball
+   carries more than the engine (hawser-agent, config, the Alpine userland):
+   it can change while the engine version stays put, and a published release's
+   assets must never be replaced — hawser builds already in the wild pin its
+   checksum. Bump the revision for a content change, reset it to 1 on an
+   engine bump. Publishing the tag triggers `rootfs.yml`, which rebuilds from
+   source (or restores the cached binaries), runs the smoke test, and attaches
+   the three assets. (The first release predates the scheme and is tagged bare
+   `rootfs-v29.7.2`.)
 2. **Copy the published checksum into the manifest.** Take the value from the
    uploaded `.sha256` and put it in `manifest.json` under
    `engines[].rootfs.sha256`, confirming the `url` matches the tag you used.

--- a/guest/rootfs/boot-test.sh
+++ b/guest/rootfs/boot-test.sh
@@ -23,8 +23,9 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 out="${1:?usage: boot-test.sh <out-dir>}"
 # shellcheck source=versions.env
 . "$here/versions.env"
+rootfs_version="${ENGINE_VERSION}-${ROOTFS_REVISION}"
 
-tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
+tarball="$out/hawser-rootfs-${rootfs_version}.tar.gz"
 test -f "$tarball" || { echo "missing $tarball"; exit 1; }
 
 image="hawser-boot-test:${ENGINE_VERSION}"

--- a/guest/rootfs/build.sh
+++ b/guest/rootfs/build.sh
@@ -13,6 +13,7 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 out="${1:-$here/out}"
 # shellcheck source=versions.env
 . "$here/versions.env"
+rootfs_version="${ENGINE_VERSION}-${ROOTFS_REVISION}"
 
 mkdir -p "$out"
 work="$(mktemp -d)"
@@ -114,7 +115,7 @@ cp "$here/assemble.Dockerfile" "$ctx/Dockerfile"
 tag="hawser-rootfs:${ENGINE_VERSION}"
 docker build --build-arg "ALPINE_TAG=${ALPINE_BRANCH#v}" -t "$tag" "$ctx"
 
-tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
+tarball="$out/hawser-rootfs-${rootfs_version}.tar.gz"
 echo "==> exporting $tarball"
 # docker export writes the container filesystem with correct ownership and
 # without the pseudo-filesystems, which is exactly what `wsl --import` wants.
@@ -128,7 +129,7 @@ docker rm -f "$cid" >/dev/null
 (cd "$out" && sha256sum "$(basename "$tarball")" > "$(basename "$tarball").sha256")
 
 echo "==> SBOM"
-"$here/sbom.sh" "$here/versions.env" "$out/hawser-rootfs-${ENGINE_VERSION}.spdx.json"
+"$here/sbom.sh" "$here/versions.env" "$out/hawser-rootfs-${rootfs_version}.spdx.json"
 
 ls -la "$out"
 echo "OK"

--- a/guest/rootfs/reference-diff.sh
+++ b/guest/rootfs/reference-diff.sh
@@ -17,8 +17,9 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 out="${1:?usage: reference-diff.sh <out-dir>}"
 # shellcheck source=versions.env
 . "$here/versions.env"
+rootfs_version="${ENGINE_VERSION}-${ROOTFS_REVISION}"
 
-tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
+tarball="$out/hawser-rootfs-${rootfs_version}.tar.gz"
 test -f "$tarball" || { echo "missing $tarball"; exit 1; }
 
 work="$(mktemp -d)"

--- a/guest/rootfs/sbom.sh
+++ b/guest/rootfs/sbom.sh
@@ -34,8 +34,8 @@ JSON
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "hawser-rootfs-${ENGINE_VERSION}",
-  "documentNamespace": "https://github.com/zcsizmadia/hawser/spdx/rootfs-${ENGINE_VERSION}",
+  "name": "hawser-rootfs-${ENGINE_VERSION}-${ROOTFS_REVISION}",
+  "documentNamespace": "https://github.com/zcsizmadia/hawser/spdx/rootfs-${ENGINE_VERSION}-${ROOTFS_REVISION}",
   "creationInfo": {
     "created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
     "creators": ["Tool: hawser-rootfs-build", "Organization: Hawser"]
@@ -49,6 +49,9 @@ JSON
   pkg "runc" "$RUNC_VERSION" "https://github.com/opencontainers/runc.git" "Apache-2.0"
   pkg "buildkit" "$BUILDKIT_VERSION" "https://github.com/moby/buildkit.git" "Apache-2.0"
   pkg "go" "$GO_VERSION" "https://go.dev/dl/" "BSD-3-Clause"
+  # The agent is versioned by this repository itself; the rootfs revision is
+  # its packaging version, and the git remote is its provenance.
+  pkg "hawser-agent" "rootfs-r${ROOTFS_REVISION}" "https://github.com/zcsizmadia/hawser.git" "Apache-2.0"
   cat <<'JSON'
 
   ]

--- a/guest/rootfs/smoke-test.sh
+++ b/guest/rootfs/smoke-test.sh
@@ -10,9 +10,10 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 out="${1:?usage: smoke-test.sh <out-dir>}"
 # shellcheck source=versions.env
 . "$here/versions.env"
+rootfs_version="${ENGINE_VERSION}-${ROOTFS_REVISION}"
 
-tarball="$out/hawser-rootfs-${ENGINE_VERSION}.tar.gz"
-sbom="$out/hawser-rootfs-${ENGINE_VERSION}.spdx.json"
+tarball="$out/hawser-rootfs-${rootfs_version}.tar.gz"
+sbom="$out/hawser-rootfs-${rootfs_version}.spdx.json"
 
 echo "==> artifacts present"
 test -f "$tarball" || { echo "missing $tarball"; exit 1; }

--- a/guest/rootfs/versions.env
+++ b/guest/rootfs/versions.env
@@ -21,6 +21,14 @@ BUILDKIT_VERSION=v0.27.0
 # Floor is set by moby's go.mod (docker-v29.7.2 requires >= 1.26.3).
 GO_VERSION=1.26.7
 
+# Packaging revision of the rootfs itself. The tarball carries more than the
+# engine (the hawser-agent, config, Alpine userland), so it can change while
+# ENGINE_VERSION stays put; the artifact version is ENGINE_VERSION-REVISION,
+# Debian-style. Bump this when rootfs contents change without an engine bump;
+# reset to 1 on an engine bump. (The first 29.7.2 release predates the scheme
+# and is tagged bare, as rootfs-v29.7.2.)
+ROOTFS_REVISION=2
+
 # Bump to force CI to recompile the engine even when nothing above changed —
 # the escape hatch for a poisoned cache or a change to build.sh's docker
 # invocation, which the cache key deliberately does not cover.

--- a/internal/pipeproxy/pipename_windows_test.go
+++ b/internal/pipeproxy/pipename_windows_test.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/Microsoft/go-winio"
 	"github.com/zcsizmadia/hawser/internal/pipeproxy"
 )
 
@@ -41,13 +43,16 @@ func TestPipeInUseDetectsALiveListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	// Accept in the background: the probe dials, so something must answer.
+	// Accept exactly once, and prove it finished before Close is called.
+	// An open-ended accept LOOP deadlocked this test rarely on CI (a 10m
+	// timeout): winio's listener Close *sends* on an unbuffered closeCh while
+	// a pending Accept sends on acceptCh, the listenerRoutine's select picks
+	// between them at random, and an unlucky pick parks Close forever. With
+	// the accept known-complete, Close has no competitor and is deterministic.
+	accepted := make(chan struct{})
 	go func() {
-		for {
-			c, err := l.Accept()
-			if err != nil {
-				return
-			}
+		defer close(accepted)
+		if c, err := l.Accept(); err == nil {
 			c.(net.Conn).Close()
 		}
 	}()
@@ -55,6 +60,19 @@ func TestPipeInUseDetectsALiveListener(t *testing.T) {
 	if !pipeproxy.PipeInUse(name) {
 		t.Errorf("%s reported free while a listener held it", name)
 	}
+
+	// The probe's instant dial-and-close can land as ERROR_NO_DATA inside the
+	// listener, which retries and waits for another client — leaving the
+	// accept above pending. A second dial, held open until the accept is
+	// observed done, releases it on that path; on the ordinary path the accept
+	// is already done and this dial simply fails against a closed-or-busy
+	// instance, which is fine either way.
+	timeout := 250 * time.Millisecond
+	if c, err := winio.DialPipe(name, &timeout); err == nil {
+		<-accepted
+		c.Close()
+	}
+	<-accepted
 
 	l.Close()
 	if pipeproxy.PipeInUse(name) {


### PR DESCRIPTION
Prerequisite for re-releasing the rootfs with the agent baked in (#40, follows #51/#52).

The tarball now carries more than the engine — hawser-agent, config, the Alpine userland — so it can change while `ENGINE_VERSION` stays put. And a published release''s assets must never be replaced: hawser builds in the wild pin the checksum (v0.1.0 pins the bare `rootfs-v29.7.2` release today).

- `ROOTFS_REVISION` in `versions.env`, Debian-style: artifacts become `hawser-rootfs-29.7.2-2.tar.gz` under tag `rootfs-v29.7.2-2`; bump for a content change, reset to 1 on an engine bump.
- All four pipeline scripts derive `rootfs_version` after sourcing `versions.env`; the reference-diff still compares against Docker''s bundle by bare `ENGINE_VERSION`.
- SBOM gains a `hawser-agent` package (this repo as provenance) and carries the revision in its document name.
- `rootfs.yml` needs no change (uploads `out/*` by glob); RELEASING.md documents the scheme.

After merge: publish release `rootfs-v29.7.2-2`, then the manifest-checksum PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)