### PR TITLE
Manifest → rootfs 29.7.2-2; #35 regression flips to fixed

### DIFF
--- a/internal/release/manifest.json
+++ b/internal/release/manifest.json
@@ -16,8 +16,8 @@
       "version": "29.7.2",
       "default": true,
       "rootfs": {
-        "url": "https://github.com/zcsizmadia/hawser/releases/download/rootfs-v29.7.2/hawser-rootfs-29.7.2.tar.gz",
-        "sha256": "155da2c816cc04feb5abf0be7613a3381698314cac099bd7273666ec650535ce"
+        "url": "https://github.com/zcsizmadia/hawser/releases/download/rootfs-v29.7.2-2/hawser-rootfs-29.7.2-2.tar.gz",
+        "sha256": "d61ad6d99b48d1b5690957f08d74e2ca2e3e577bac22772388f20a0cf1ee7de7"
       },
       "components": {
         "dockerd": "29.7.2",

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -76,6 +76,18 @@ func TestEmbeddedManifestMatchesRootfsPins(t *testing.T) {
 			t.Errorf("manifest %s = %q, versions.env %s = %q", component, got, envKey, want)
 		}
 	}
+
+	// The rootfs URL must point at the *revisioned* artifact
+	// (ENGINE_VERSION-ROOTFS_REVISION): a revision bump that forgets the
+	// manifest would otherwise keep installing the previous rootfs while
+	// `hawser version` claims the new one's contents.
+	if rev := pins["ROOTFS_REVISION"]; rev != "" {
+		wantName := "hawser-rootfs-" + pins["ENGINE_VERSION"] + "-" + rev + ".tar.gz"
+		if !strings.HasSuffix(e.Rootfs.URL, "/"+wantName) {
+			t.Errorf("manifest rootfs URL %q does not end in %q (versions.env ROOTFS_REVISION=%s)",
+				e.Rootfs.URL, wantName, rev)
+		}
+	}
 }
 
 func TestEngineSelectionIsExact(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -80,6 +80,7 @@ func TestAcceptance(t *testing.T) {
 		{"LogsFollowStreams", stageLogsFollow},
 		{"ComposeStack", stageCompose},
 		{"InterruptedClientDoesNotWedgeBridge", stageInterrupt},
+		{"VsockPathServedEverything", stageVsockServed},
 		{"Uninstall", stageUninstall},
 		{"NothingLeftBehind", stageClean},
 		{"DockerDesktopStillWorks", stageDesktopIntact},
@@ -394,10 +395,14 @@ services:
 
 func stageInterrupt(t *testing.T, s *state) {
 	// The #35 shape: kill a client mid-request, then prove the bridge still
-	// answers. The leak itself is bounded rather than fixed until the v0.2
-	// agent, so the assertion here is responsiveness, not process count.
-	cmd := exec.Command(s.docker, "logs", "-f", "nonexistent-will-wait")
-	cmd.Env = s.dockerEnv()
+	// answers AND that nothing leaked. Under the v0.1 socat relay this stage
+	// could only assert responsiveness (the leak was bounded by an idle
+	// timeout, not fixed); with the vsock agent (#40) both ends of the
+	// transport are owned, a killed client's connection tears down
+	// explicitly, and the wsl.exe count must return to its pre-interrupt
+	// value — the regression #35 asked for.
+	before := wslProcCount(t)
+
 	long := exec.Command(s.docker, "run", "--rm", "alpine:latest", "sleep", "30")
 	long.Env = s.dockerEnv()
 	if err := long.Start(); err != nil {
@@ -411,6 +416,34 @@ func stageInterrupt(t *testing.T, s *state) {
 	must(t, out, err, "engine after an interrupted client")
 	if out == "" {
 		t.Error("engine did not answer after a client was killed mid-run")
+	}
+
+	// Teardown is not instantaneous; give it a moment, but far less than the
+	// 5-minute socat idle timeout that used to be the only backstop.
+	deadline := time.Now().Add(30 * time.Second)
+	after := wslProcCount(t)
+	for after > before && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
+		after = wslProcCount(t)
+	}
+	if after > before {
+		t.Errorf("wsl.exe count %d did not return to the pre-interrupt %d; the interrupted client leaked its relay", after, before)
+	}
+}
+
+func stageVsockServed(t *testing.T, s *state) {
+	// The suite installed from the published release, so this asserts the
+	// shipping artifact chain end to end: the rootfs carries hawser-agent,
+	// the proxy's vsock dialer reached it, and no connection needed the socat
+	// fallback. The fallback logs one edge-triggered warning the moment it is
+	// first used; its absence over a suite's worth of traffic means the fast
+	// path served everything.
+	logBytes, err := os.ReadFile(filepath.Join(s.stateDir, "proxy-e2e.log"))
+	if err != nil {
+		t.Fatalf("reading proxy log: %v", err)
+	}
+	if strings.Contains(string(logBytes), "fallback transport") {
+		t.Error("proxy degraded to the socat fallback; the published rootfs should carry a reachable hawser-agent")
 	}
 }
 


### PR DESCRIPTION
Final slice of #40, completing the chain rootfs release → manifest → host dialer. Closes #40, closes #35.

## What

- **`manifest.json`** points at [`rootfs-v29.7.2-2`](https://github.com/zcsizmadia/hawser/releases/tag/rootfs-v29.7.2-2) with its published checksum — every fresh `hawser install` now gets the hawser-agent vsock relay.
- **`release_test`** locks the manifest URL to `versions.env`''s `ROOTFS_REVISION`: a future revision bump that forgets the manifest fails tests instead of silently installing the previous rootfs.
- **e2e `InterruptedClient`** graduates from "bridge still answers" to the regression #35 asked for: wsl.exe count **returns to baseline** after a client is killed mid-request (30s allowance vs the 5-minute socat idle timeout that used to be the only backstop).
- **New e2e stage `VsockPathServedEverything`**: after a suite''s worth of traffic the proxy log must not contain the fallback dialer''s edge-triggered degradation warning — proving the *published* rootfs carries a reachable agent and the fast path served every connection.

## Results

All 14 acceptance stages green in **36.8s** against the published release (vs ~42s on the socat path); all unit packages green. Measured earlier on this machine: `docker version` ~80ms over vsock vs ~150ms over socat, ~0.6ms per-connection transport cost vs ~165ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)