### PR TITLE
On-demand engine start + idle-timeout (hawser config)

### DIFF
--- a/cmd/hawser/config.go
+++ b/cmd/hawser/config.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/zcsizmadia/hawser/internal/config"
+	"github.com/zcsizmadia/hawser/internal/provision"
+)
+
+func runConfig(args []string) int {
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	stateDir := fs.String("state-dir", "", "override Hawser's state directory")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser config                    list all settings
+       hawser config get <key>          print one value
+       hawser config set <key> <value>  change one value
+
+Settings apply live: the supervisor re-reads them every few seconds, so no
+restart is needed.
+
+keys:
+  %s   how long the bridge must be quiet (no connections, no running
+                 containers) before the engine is stopped to reclaim its RAM;
+                 the next docker command starts it again. A duration like 20m
+                 or 1h, or "off" (the default).
+
+Exit codes: 0 ok, %d error, %d usage.
+`, config.KeyIdleTimeout, exitError, exitUsage)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
+	rest := fs.Args()
+
+	switch {
+	case len(rest) == 0:
+		all, err := config.All(opts.StateDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		keys := make([]string, 0, len(all))
+		for k := range all {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("%s = %s\n", k, all[k])
+		}
+		return exitOK
+
+	case rest[0] == "get" && len(rest) == 2:
+		v, err := config.Get(opts.StateDir, rest[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		fmt.Println(v)
+		return exitOK
+
+	case rest[0] == "set" && len(rest) == 3:
+		if err := config.Set(opts.StateDir, rest[1], rest[2]); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		v, _ := config.Get(opts.StateDir, rest[1])
+		fmt.Printf("%s = %s\n", rest[1], v)
+		return exitOK
+
+	default:
+		fmt.Fprintf(os.Stderr, "hawser: config %s: unrecognized; see `hawser config --help`\n",
+			strings.Join(rest, " "))
+		return exitUsage
+	}
+}

--- a/cmd/hawser/idle.go
+++ b/cmd/hawser/idle.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/pipeproxy"
+	"github.com/zcsizmadia/hawser/internal/supervise"
+)
+
+// demandDialer wakes an idle-stopped engine before dialing it: the first
+// docker command after an idle stop pays the cold start and works, instead of
+// failing against a stopped engine (#41).
+type demandDialer struct {
+	sup   *supervise.Supervisor
+	inner pipeproxy.Dialer
+}
+
+func (d *demandDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	// Demand is a no-op unless the engine is idle-stopped, so the healthy
+	// path pays one flag check, not an engine probe.
+	if err := d.sup.Demand(ctx); err != nil {
+		return nil, fmt.Errorf("waking the engine: %w", err)
+	}
+	return d.inner.Dial(ctx)
+}
+
+// rwcConn adapts the dialer's io.ReadWriteCloser to net.Conn for http.
+// Deadlines are no-ops; the probe's lifetime is bounded by its context.
+type rwcConn struct {
+	io.ReadWriteCloser
+}
+
+type dummyAddr string
+
+func (a dummyAddr) Network() string { return string(a) }
+func (a dummyAddr) String() string  { return string(a) }
+
+func (rwcConn) LocalAddr() net.Addr              { return dummyAddr("hawser") }
+func (rwcConn) RemoteAddr() net.Addr             { return dummyAddr("engine") }
+func (rwcConn) SetDeadline(time.Time) error      { return nil }
+func (rwcConn) SetReadDeadline(time.Time) error  { return nil }
+func (rwcConn) SetWriteDeadline(time.Time) error { return nil }
+
+// busyProbe asks the engine whether any containers are running, over the same
+// transport the bridge uses. The idle stop needs a definite "no": any error
+// here vetoes it (supervise.Supervisor.Busy's contract).
+func busyProbe(dialer pipeproxy.Dialer) func(ctx context.Context) (bool, error) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				rwc, err := dialer.Dial(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return rwcConn{rwc}, nil
+			},
+			// One probe, one connection: the engine socket is not a place to
+			// pool idle keep-alives that would themselves look like activity.
+			DisableKeepAlives: true,
+		},
+	}
+	return func(ctx context.Context) (bool, error) {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		// /containers/json lists RUNNING containers by default, which is
+		// exactly the "would an idle stop kill something" question.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://engine/containers/json", nil)
+		if err != nil {
+			return false, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("engine returned %s to the container probe", resp.Status)
+		}
+		var containers []json.RawMessage
+		if err := json.NewDecoder(resp.Body).Decode(&containers); err != nil {
+			return false, err
+		}
+		return len(containers) > 0, nil
+	}
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -28,6 +28,7 @@ type command struct {
 func commands() []command {
 	return []command{
 		{"autostart", "start the supervisor at logon: enable, disable, status", runAutostart},
+		{"config", "list, get, or set Hawser settings (idle-timeout)", runConfig},
 		{"install", "provision the engine distro and start it", runInstall},
 		{"proxy", "serve the docker pipe in the foreground (debug mode)", runProxy},
 		{"restart", "stop the engine, then start it", runRestart},

--- a/cmd/hawser/supervise.go
+++ b/cmd/hawser/supervise.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/zcsizmadia/hawser/internal/config"
 	"github.com/zcsizmadia/hawser/internal/dockerctx"
 	"github.com/zcsizmadia/hawser/internal/logging"
 	"github.com/zcsizmadia/hawser/internal/pipeproxy"
@@ -62,7 +63,7 @@ crash restart with backoff, recovery from `+"`wsl --shutdown`"+` and sleep/resum
 honoring `+"`hawser stop`"+` until `+"`hawser start`"+`. One instance per install.
 
 Runs in the foreground; `+"`hawser start`"+` spawns it in the background, and the
-logon autostart (upcoming) runs it for you. Logs go to supervisor.log in the
+logon autostart (`+"`hawser autostart`"+`) runs it for you. Logs go to supervisor.log in the
 state directory (rotated) as well as stderr.
 
 flags:
@@ -126,20 +127,35 @@ flags:
 	ctx, stop := interruptible()
 	defer stop()
 
-	// The reconciler keeps the engine matching the desired state...
-	sup := &supervise.Supervisor{
-		Engine: engineAdapter{p: p, opts: opts},
-		Config: supervise.Config{StateDir: opts.StateDir},
-		Log:    log,
-	}
-	go sup.Run(ctx)
-
-	// ...while the pipe server carries traffic. Both stop together.
+	// Server and supervisor are deliberately entangled (#41): the server's
+	// traffic feeds the supervisor's idle detection, and the supervisor's
+	// Demand wakes an idle-stopped engine for the server's next connection.
+	dialer := engineDialer(targetDistro, "", log)
 	srv := &pipeproxy.Server{
-		Dialer:  engineDialer(targetDistro, "", log),
 		Logger:  log,
 		Handler: pipeproxy.RewriteBinds,
 	}
+	sup := &supervise.Supervisor{
+		Engine:   engineAdapter{p: p, opts: opts},
+		Config:   supervise.Config{StateDir: opts.StateDir},
+		Log:      log,
+		Activity: srv,
+		// Read per tick, so `hawser config set idle-timeout` applies live. A
+		// corrupt config file reads as "off": never idle-stop on a guess.
+		IdleTimeout: func() time.Duration {
+			c, err := config.Load(opts.StateDir)
+			if err != nil {
+				log.Warn("config unreadable; idle stops disabled", "error", err)
+				return 0
+			}
+			return c.IdleTimeout
+		},
+		Busy: busyProbe(dialer),
+	}
+	srv.Dialer = &demandDialer{sup: sup, inner: dialer}
+	go sup.Run(ctx)
+
+	// The pipe server carries traffic; both stop together.
 	if err := srv.Serve(ctx, listener); err != nil {
 		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
 		return exitError
@@ -177,6 +193,13 @@ running, and waits for the engine to answer.
 
 	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
 	if err := supervise.WriteDesired(opts.StateDir, supervise.DesiredRunning); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	// Removing the idle marker is the wake-up poke: an idle-stopped engine is
+	// down on purpose, and the supervisor will not restart it while the marker
+	// stands — but `hawser start` is the user saying now.
+	if err := supervise.WriteEngineState(opts.StateDir, supervise.EngineActive); err != nil {
 		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
 		return exitError
 	}
@@ -235,6 +258,9 @@ stopped. Only Hawser's own distro is touched, never other WSL distros.
 		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
 		return exitError
 	}
+	// An explicit stop supersedes an idle stop; the marker would make status
+	// claim "idle (wakes on demand)" about an engine that must stay down.
+	supervise.WriteEngineState(opts.StateDir, supervise.EngineActive)
 
 	p := &provision.Provisioner{Logger: cliLogger(false)}
 	distro, ok := resolveDistro(p, opts)
@@ -301,8 +327,13 @@ func runStatus(args []string) int {
 		if supervise.Held(opts.StateDir) {
 			st.Supervisor = "running"
 		}
-		if p.EngineRunning(context.Background(), opts) {
+		switch {
+		case p.EngineRunning(context.Background(), opts):
 			st.Engine = "running"
+		case supervise.ReadEngineState(opts.StateDir) == supervise.EngineIdle:
+			// Down by design (#41): the idle timeout elapsed, and the next
+			// docker command wakes it. Scripts get to tell this from broken.
+			st.Engine = "idle"
 		}
 	}
 
@@ -316,7 +347,8 @@ func runStatus(args []string) int {
 	fmt.Printf("distro      %s\nsupervisor  %s\nengine      %s\ndesired     %s\n",
 		st.Distro, st.Supervisor, st.Engine, st.Desired)
 	// Exit code mirrors engine health, so scripts can gate on it directly.
-	if st.Engine != "running" {
+	// Idle counts as healthy: the engine is a docker command away, on purpose.
+	if st.Engine != "running" && st.Engine != "idle" {
 		return exitError
 	}
 	return exitOK

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,180 @@
+// Package config is Hawser's user-tunable settings: a small JSON file in the
+// state directory, edited through `hawser config` rather than by hand so
+// every value is validated on the way in.
+//
+// Settings are read fresh at each use (the supervisor reads per tick), so a
+// `hawser config set` takes effect without restarting anything.
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// KeyIdleTimeout is how long the bridge must be quiet (no open connections,
+// no running containers) before the supervisor stops the engine to return
+// its RAM. "off" (the default) disables idle stops entirely.
+const KeyIdleTimeout = "idle-timeout"
+
+// path is the settings file inside the state dir.
+func path(stateDir string) string {
+	return filepath.Join(stateDir, "config.json")
+}
+
+// Config is the parsed, validated view.
+type Config struct {
+	// IdleTimeout of zero means idle stops are off.
+	IdleTimeout time.Duration
+}
+
+// Load parses the settings file. A missing file is the default configuration,
+// not an error; a corrupt one is an error, because silently reverting a
+// user's settings to defaults is worse than telling them.
+func Load(stateDir string) (Config, error) {
+	raw, err := load(stateDir)
+	if err != nil {
+		return Config{}, err
+	}
+	var c Config
+	if v, ok := raw[KeyIdleTimeout]; ok {
+		d, err := parseIdleTimeout(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("config %s: %w", KeyIdleTimeout, err)
+		}
+		c.IdleTimeout = d
+	}
+	return c, nil
+}
+
+func load(stateDir string) (map[string]string, error) {
+	b, err := os.ReadFile(path(stateDir))
+	if os.IsNotExist(err) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	m := map[string]string{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path(stateDir), err)
+	}
+	return m, nil
+}
+
+// validators parse-and-normalize each known key; unknown keys are refused so
+// a typo ("idle-timout") fails loudly instead of configuring nothing.
+var validators = map[string]func(string) (string, error){
+	KeyIdleTimeout: func(v string) (string, error) {
+		d, err := parseIdleTimeout(v)
+		if err != nil {
+			return "", err
+		}
+		if d == 0 {
+			return "off", nil
+		}
+		return d.String(), nil
+	},
+}
+
+func parseIdleTimeout(v string) (time.Duration, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "off", "0", "":
+		return 0, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a duration (try 20m, 1h30m, or off)", v)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("%q is negative", v)
+	}
+	if d < 10*time.Second {
+		return 0, fmt.Errorf("%q is below the 10s minimum; use off to disable", v)
+	}
+	return d, nil
+}
+
+// Keys lists the settable keys, for help text.
+func Keys() []string {
+	ks := make([]string, 0, len(validators))
+	for k := range validators {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// Get returns the stored value for a known key, or its default.
+func Get(stateDir, key string) (string, error) {
+	if _, ok := validators[key]; !ok {
+		return "", fmt.Errorf("unknown config key %q (known: %s)", key, strings.Join(Keys(), ", "))
+	}
+	raw, err := load(stateDir)
+	if err != nil {
+		return "", err
+	}
+	if v, ok := raw[key]; ok {
+		return v, nil
+	}
+	return defaultFor(key), nil
+}
+
+func defaultFor(key string) string {
+	switch key {
+	case KeyIdleTimeout:
+		return "off"
+	}
+	return ""
+}
+
+// Set validates and stores one key, atomically.
+func Set(stateDir, key, value string) error {
+	validate, ok := validators[key]
+	if !ok {
+		return fmt.Errorf("unknown config key %q (known: %s)", key, strings.Join(Keys(), ", "))
+	}
+	normalized, err := validate(value)
+	if err != nil {
+		return err
+	}
+	raw, err := load(stateDir)
+	if err != nil {
+		return err
+	}
+	raw[key] = normalized
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	b, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path(stateDir) + ".tmp"
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := os.Rename(tmp, path(stateDir)); err != nil {
+		return fmt.Errorf("committing config: %w", err)
+	}
+	return nil
+}
+
+// All returns every stored setting plus defaults for unset known keys.
+func All(stateDir string) (map[string]string, error) {
+	raw, err := load(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range Keys() {
+		if _, ok := raw[k]; !ok {
+			raw[k] = defaultFor(k)
+		}
+	}
+	return raw, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefaultsWhenNoFile(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load with no file: %v", err)
+	}
+	if c.IdleTimeout != 0 {
+		t.Errorf("default IdleTimeout = %v, want 0 (off)", c.IdleTimeout)
+	}
+	if v, err := Get(dir, KeyIdleTimeout); err != nil || v != "off" {
+		t.Errorf("Get default = %q, %v; want off", v, err)
+	}
+}
+
+func TestSetGetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := Set(dir, KeyIdleTimeout, "20m"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if v, _ := Get(dir, KeyIdleTimeout); v != "20m0s" {
+		t.Errorf("Get = %q, want normalized 20m0s", v)
+	}
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.IdleTimeout != 20*time.Minute {
+		t.Errorf("IdleTimeout = %v, want 20m", c.IdleTimeout)
+	}
+}
+
+func TestSetOff(t *testing.T) {
+	dir := t.TempDir()
+	Set(dir, KeyIdleTimeout, "1h")
+	for _, off := range []string{"off", "0", "OFF"} {
+		if err := Set(dir, KeyIdleTimeout, off); err != nil {
+			t.Fatalf("Set(%q): %v", off, err)
+		}
+		c, _ := Load(dir)
+		if c.IdleTimeout != 0 {
+			t.Errorf("after Set(%q), IdleTimeout = %v, want 0", off, c.IdleTimeout)
+		}
+	}
+}
+
+func TestSetRejectsBadValues(t *testing.T) {
+	dir := t.TempDir()
+	for _, bad := range []string{"soon", "-5m", "2s", "5"} {
+		if err := Set(dir, KeyIdleTimeout, bad); err == nil {
+			t.Errorf("Set(%q) accepted", bad)
+		}
+	}
+	// And nothing was persisted by the failures.
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); !os.IsNotExist(err) {
+		t.Error("a rejected Set still wrote the config file")
+	}
+}
+
+func TestUnknownKeyRefused(t *testing.T) {
+	dir := t.TempDir()
+	if err := Set(dir, "idle-timout", "20m"); err == nil {
+		t.Error("typo'd key accepted; it would configure nothing")
+	}
+	if _, err := Get(dir, "nope"); err == nil {
+		t.Error("unknown key Get succeeded")
+	}
+}
+
+func TestCorruptFileIsAnErrorNotDefaults(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json"), 0o644)
+	if _, err := Load(dir); err == nil {
+		t.Error("corrupt config silently became defaults")
+	}
+}
+
+func TestAllListsDefaultsAndSet(t *testing.T) {
+	dir := t.TempDir()
+	Set(dir, KeyIdleTimeout, "30m")
+	all, err := All(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if all[KeyIdleTimeout] != "30m0s" {
+		t.Errorf("All()[%s] = %q", KeyIdleTimeout, all[KeyIdleTimeout])
+	}
+}

--- a/internal/pipeproxy/relay.go
+++ b/internal/pipeproxy/relay.go
@@ -23,6 +23,8 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 // Dialer opens one connection to the engine socket. Production dials through
@@ -63,7 +65,27 @@ type Server struct {
 
 	mu     sync.Mutex
 	active map[io.Closer]struct{}
+
+	// clients and lastActivity feed idle detection (supervise.Activity):
+	// how many client connections are open, and when one last opened or
+	// closed (unix nanos; 0 = never).
+	clients      atomic.Int64
+	lastActivity atomic.Int64
 }
+
+// ActiveConns is how many client connections are open right now.
+func (s *Server) ActiveConns() int { return int(s.clients.Load()) }
+
+// LastActivity is when a connection last opened or closed; zero time if none.
+func (s *Server) LastActivity() time.Time {
+	ns := s.lastActivity.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+func (s *Server) touch() { s.lastActivity.Store(time.Now().UnixNano()) }
 
 // track registers a connection so shutdown can close it. Without this, a
 // client holding a streaming connection open (docker logs -f, docker events)
@@ -138,6 +160,13 @@ func (s *Server) Serve(ctx context.Context, l net.Listener) error {
 func (s *Server) handle(ctx context.Context, client net.Conn) {
 	log := s.logger()
 	defer client.Close()
+
+	s.clients.Add(1)
+	s.touch()
+	defer func() {
+		s.clients.Add(-1)
+		s.touch()
+	}()
 
 	s.track(client)
 	defer s.untrack(client)

--- a/internal/pipeproxy/rewrite.go
+++ b/internal/pipeproxy/rewrite.go
@@ -73,16 +73,65 @@ func RewriteBinds(client net.Conn, engine io.ReadWriteCloser) error {
 		}
 
 		// resp.Write streams the body as it arrives, which is what keeps
-		// `docker logs -f` and pull progress incremental.
-		if err := resp.Write(client); err != nil {
+		// `docker logs -f` and pull progress incremental. But a streaming
+		// response also needs a watchdog on the client: with a quiet source
+		// (docker compose's /events subscription after the stack is down),
+		// resp.Write blocks reading the engine and never touches the dead
+		// client, so a vanished CLI would pin this relay open forever — found
+		// as "idle stop deferred: open client connections" (#41), the same
+		// half-open class as #35 on a new surface. The Peek doubles as the
+		// wait for the client's next request, so exactly one goroutine reads
+		// clientR at any moment.
+		peekc := make(chan error, 1)
+		go func() {
+			_, err := clientR.Peek(1)
+			peekc <- err
+		}()
+		writec := make(chan error, 1)
+		go func() { writec <- resp.Write(client) }()
+
+		var werr error
+		peeked := false
+		select {
+		case werr = <-writec:
+		case perr := <-peekc:
+			peeked = true
+			if perr != nil {
+				// Client is gone mid-stream. Closing the engine side unblocks
+				// resp.Write; an ordinary disconnect, not a fault.
+				engine.Close()
+				<-writec
+				resp.Body.Close()
+				trace("DONE %s (client vanished mid-stream)", req.URL.Path)
+				return nil
+			}
+			// Bytes arrived while the response still streams (a pipelined
+			// request): unusual for a docker client, but just wait the write
+			// out and loop.
+			werr = <-writec
+		}
+		if werr != nil {
 			resp.Body.Close()
-			return fmt.Errorf("forward response: %w", err)
+			return fmt.Errorf("forward response: %w", werr)
 		}
 		resp.Body.Close()
 		trace("DONE %s (close=%v)", req.URL.Path, resp.Close || req.Close)
 
 		if resp.Close || req.Close {
+			// The pending Peek goroutine unblocks when the caller closes the
+			// client conn; its channel is buffered, so nothing leaks.
 			return nil
+		}
+		if !peeked {
+			// Wait for the client's next move — its next request's first byte,
+			// or a close ending the keep-alive conversation — before looping,
+			// so ReadRequest never shares clientR with a still-blocked Peek.
+			if perr := <-peekc; perr != nil {
+				if errors.Is(perr, io.EOF) || errors.Is(perr, net.ErrClosed) {
+					return nil
+				}
+				return fmt.Errorf("await next request: %w", perr)
+			}
 		}
 	}
 }

--- a/internal/pipeproxy/rewrite_test.go
+++ b/internal/pipeproxy/rewrite_test.go
@@ -496,3 +496,47 @@ func TestRewriteUnversionedPath(t *testing.T) {
 		t.Errorf("unversioned path not rewritten: %s", got)
 	}
 }
+
+func TestClientVanishingDuringQuietStreamEndsRelay(t *testing.T) {
+	// The docker-compose /events shape: the engine sends chunked headers and
+	// then nothing (no events happening), and the client exits. The relay is
+	// blocked reading the engine, so only watching the client can notice —
+	// without it, this connection pins the bridge open forever (it held the
+	// idle-stop veto in #41, and leaked silently since v0.1).
+	client, bridgeClient := net.Pipe()
+	engineSide, bridgeEngine := net.Pipe()
+
+	done := make(chan error, 1)
+	go func() { done <- pipeproxy.RewriteBinds(bridgeClient, bridgeEngine) }()
+
+	// Engine: accept the request, answer with a chunked stream that never
+	// sends a chunk.
+	go func() {
+		br := bufio.NewReader(engineSide)
+		http.ReadRequest(br)
+		engineSide.Write([]byte("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n"))
+		// ...and then silence: no events are happening.
+	}()
+
+	req, _ := http.NewRequest("GET", "http://d/events", nil)
+	if err := req.Write(client); err != nil {
+		t.Fatal(err)
+	}
+	// Read the response head so the stream is established client-side.
+	br := bufio.NewReader(client)
+	if _, err := http.ReadResponse(br, req); err != nil {
+		t.Fatal(err)
+	}
+
+	// The client goes away without ever cancelling politely (process exit).
+	client.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("relay returned %v; a vanished client is ordinary shutdown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("relay still pinned open 5s after the client vanished; the #41 idle veto leak")
+	}
+}

--- a/internal/supervise/export_test.go
+++ b/internal/supervise/export_test.go
@@ -1,0 +1,7 @@
+package supervise
+
+import "context"
+
+// TickForTest runs one reconcile pass; the idle tests drive ticks directly
+// instead of racing a real ticker.
+func (s *Supervisor) TickForTest(ctx context.Context) { s.tick(ctx) }

--- a/internal/supervise/idle_test.go
+++ b/internal/supervise/idle_test.go
@@ -1,0 +1,210 @@
+package supervise_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zcsizmadia/hawser/internal/supervise"
+)
+
+// fakeActivity is a scriptable supervise.Activity.
+type fakeActivity struct {
+	mu    sync.Mutex
+	conns int
+	last  time.Time
+}
+
+func (f *fakeActivity) ActiveConns() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.conns
+}
+
+func (f *fakeActivity) LastActivity() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.last
+}
+
+func (f *fakeActivity) set(conns int, last time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.conns, f.last = conns, last
+}
+
+// idleSup builds a supervisor primed for idle testing: engine up, desired
+// running, idle timeout tiny, everything quiet since long ago.
+func idleSup(t *testing.T) (*supervise.Supervisor, *fakeEngine, *fakeActivity, string) {
+	t.Helper()
+	e := &fakeEngine{running: true}
+	act := &fakeActivity{last: time.Now().Add(-time.Hour)}
+	s, dir := newSup(t, e, time.Hour)
+	s.Activity = act
+	s.IdleTimeout = func() time.Duration { return 50 * time.Millisecond }
+	s.Busy = func(context.Context) (bool, error) { return false, nil }
+	return s, e, act, dir
+}
+
+// runTicks pumps the reconciler enough times, with a pause so the idle clock
+// (anchored at upSince on the first healthy tick) can age past the timeout.
+func runTicks(s *supervise.Supervisor, n int, pause time.Duration) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for i := 0; i < n; i++ {
+		s.TickForTest(ctx)
+		time.Sleep(pause)
+	}
+}
+
+func TestIdleStopsQuietEngine(t *testing.T) {
+	s, e, _, dir := idleSup(t)
+
+	runTicks(s, 3, 60*time.Millisecond)
+
+	if _, stops := e.counts(); stops != 1 {
+		t.Fatalf("engine stopped %d times, want 1 idle stop", stops)
+	}
+	if supervise.ReadEngineState(dir) != supervise.EngineIdle {
+		t.Error("idle stop did not record the idle state")
+	}
+
+	// And it STAYS down: the reconciler must not treat its own idle stop as a
+	// crash to repair.
+	runTicks(s, 3, 10*time.Millisecond)
+	if starts, _ := e.counts(); starts != 0 {
+		t.Errorf("idle-stopped engine restarted %d times by the loop", starts)
+	}
+}
+
+func TestIdleVetoedByActiveConns(t *testing.T) {
+	s, e, act, _ := idleSup(t)
+	act.set(1, time.Now().Add(-time.Hour)) // a long-lived quiet connection (docker events)
+
+	runTicks(s, 3, 60*time.Millisecond)
+	if _, stops := e.counts(); stops != 0 {
+		t.Error("engine idled while a client connection was open")
+	}
+}
+
+func TestIdleVetoedByRunningContainers(t *testing.T) {
+	s, e, _, _ := idleSup(t)
+	s.Busy = func(context.Context) (bool, error) { return true, nil }
+
+	runTicks(s, 3, 60*time.Millisecond)
+	if _, stops := e.counts(); stops != 0 {
+		t.Error("engine idled with containers running; that kills them")
+	}
+}
+
+func TestIdleVetoedWhenBusyUnknown(t *testing.T) {
+	s, e, _, _ := idleSup(t)
+	s.Busy = func(context.Context) (bool, error) { return false, errors.New("probe down") }
+
+	runTicks(s, 3, 60*time.Millisecond)
+	if _, stops := e.counts(); stops != 0 {
+		t.Error("engine idled although the container probe failed; a stop needs a definite no")
+	}
+
+	s.Busy = nil
+	runTicks(s, 3, 60*time.Millisecond)
+	if _, stops := e.counts(); stops != 0 {
+		t.Error("engine idled with no container probe wired at all")
+	}
+}
+
+func TestIdleRespectsRecentTraffic(t *testing.T) {
+	s, e, act, _ := idleSup(t)
+	act.set(0, time.Now()) // a connection just closed
+
+	runTicks(s, 2, 5*time.Millisecond)
+	if _, stops := e.counts(); stops != 0 {
+		t.Error("engine idled before the timeout elapsed after the last connection")
+	}
+}
+
+func TestDemandColdStartsIdleEngine(t *testing.T) {
+	s, e, _, dir := idleSup(t)
+	runTicks(s, 3, 60*time.Millisecond) // idle it
+	if e.Running(context.Background()) {
+		t.Fatal("precondition: engine should be idle-stopped")
+	}
+
+	if err := s.Demand(context.Background()); err != nil {
+		t.Fatalf("Demand: %v", err)
+	}
+	if !e.Running(context.Background()) {
+		t.Error("Demand did not start the engine")
+	}
+	if supervise.ReadEngineState(dir) != supervise.EngineActive {
+		t.Error("Demand left the idle marker behind")
+	}
+
+	// Demand on a non-idle engine is a no-op, not a redundant start.
+	starts, _ := e.counts()
+	s.Demand(context.Background())
+	if s2, _ := e.counts(); s2 != starts {
+		t.Error("Demand started an engine that was not idle")
+	}
+}
+
+func TestPokeWakesIdleEngine(t *testing.T) {
+	// `hawser start` deletes the engine-state file; the next tick must treat
+	// that as demand and restart.
+	s, e, _, dir := idleSup(t)
+	runTicks(s, 3, 60*time.Millisecond) // idle it
+
+	if err := supervise.WriteEngineState(dir, supervise.EngineActive); err != nil {
+		t.Fatal(err)
+	}
+	runTicks(s, 1, 0)
+	if !e.Running(context.Background()) {
+		t.Error("deleting the idle marker did not wake the engine")
+	}
+}
+
+func TestSupervisorRestartAdoptsIdleState(t *testing.T) {
+	// A new supervisor process finding engine-state=idle must not "repair"
+	// the down engine.
+	e := &fakeEngine{running: false}
+	s, dir := newSup(t, e, time.Hour)
+	if err := supervise.WriteEngineState(dir, supervise.EngineIdle); err != nil {
+		t.Fatal(err)
+	}
+
+	runTicks(s, 3, 5*time.Millisecond)
+	if starts, _ := e.counts(); starts != 0 {
+		t.Errorf("restarted supervisor started an idle-stopped engine %d times", starts)
+	}
+}
+
+func TestManualStartClearsStaleIdleMarker(t *testing.T) {
+	// Engine running + file says idle = someone started it around the
+	// supervisor; the marker is stale and must go.
+	e := &fakeEngine{running: true}
+	s, dir := newSup(t, e, time.Hour)
+	if err := supervise.WriteEngineState(dir, supervise.EngineIdle); err != nil {
+		t.Fatal(err)
+	}
+
+	runTicks(s, 1, 0)
+	if supervise.ReadEngineState(dir) != supervise.EngineActive {
+		t.Error("stale idle marker survived a healthy tick")
+	}
+}
+
+func TestExplicitStopClearsIdle(t *testing.T) {
+	s, e, _, dir := idleSup(t)
+	runTicks(s, 3, 60*time.Millisecond) // idle it
+	e.setRunning(true)                  // engine got started somehow
+
+	if err := supervise.WriteDesired(dir, supervise.DesiredStopped); err != nil {
+		t.Fatal(err)
+	}
+	runTicks(s, 1, 0)
+	if supervise.ReadEngineState(dir) != supervise.EngineActive {
+		t.Error("explicit stop left the idle marker; status would lie")
+	}
+}

--- a/internal/supervise/state.go
+++ b/internal/supervise/state.go
@@ -59,3 +59,57 @@ func WriteDesired(stateDir string, d Desired) error {
 	}
 	return nil
 }
+
+// EngineState is the supervisor's own record of *why* the engine is down —
+// distinct from Desired, which is what the user asked for. Its one non-default
+// value, idle, is what lets `hawser status` (and scripts) tell "stopped by
+// design, will wake on demand" from "broken".
+type EngineState string
+
+const (
+	// EngineActive is the normal state; represented by the file being absent.
+	EngineActive EngineState = "active"
+	// EngineIdle means the supervisor stopped the engine because the bridge
+	// was quiet for the configured idle-timeout. Deleting the file is the
+	// wake-up poke: the supervisor treats its disappearance as demand.
+	EngineIdle EngineState = "idle"
+)
+
+func engineStatePath(stateDir string) string {
+	return filepath.Join(stateDir, "engine-state")
+}
+
+// ReadEngineState returns the recorded state; absent or unreadable is active.
+func ReadEngineState(stateDir string) EngineState {
+	b, err := os.ReadFile(engineStatePath(stateDir))
+	if err != nil {
+		return EngineActive
+	}
+	if EngineState(strings.TrimSpace(string(b))) == EngineIdle {
+		return EngineIdle
+	}
+	return EngineActive
+}
+
+// WriteEngineState records the state atomically; writing active removes the
+// file, so absence stays the ground truth for the normal case.
+func WriteEngineState(stateDir string, st EngineState) error {
+	if st == EngineActive {
+		err := os.Remove(engineStatePath(stateDir))
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	tmp := engineStatePath(stateDir) + ".tmp"
+	if err := os.WriteFile(tmp, []byte(st+"\n"), 0o644); err != nil {
+		return fmt.Errorf("writing engine state: %w", err)
+	}
+	if err := os.Rename(tmp, engineStatePath(stateDir)); err != nil {
+		return fmt.Errorf("committing engine state: %w", err)
+	}
+	return nil
+}

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -3,6 +3,7 @@ package supervise
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -45,16 +46,65 @@ func (c Config) backoffMax() time.Duration {
 	return c.BackoffMax
 }
 
+// Activity reports bridge traffic, for idle detection. pipeproxy.Server
+// implements it.
+type Activity interface {
+	// ActiveConns is how many client connections are open right now.
+	ActiveConns() int
+	// LastActivity is when a connection last opened or closed; the zero time
+	// if there has been none.
+	LastActivity() time.Time
+}
+
 // Supervisor reconciles the engine with the desired state.
 type Supervisor struct {
 	Engine Engine
 	Config Config
 	Log    *slog.Logger
 
+	// Activity feeds idle detection (#41). Nil disables idle stops.
+	Activity Activity
+
+	// IdleTimeout is read every tick, so `hawser config set idle-timeout`
+	// takes effect without a restart. Nil or a zero return disables idle
+	// stops.
+	IdleTimeout func() time.Duration
+
+	// Busy reports whether the engine has running containers. Idle stops
+	// require a definite "no": nil, an error, or true all veto the stop,
+	// because stopping the engine kills whatever runs in it.
+	Busy func(ctx context.Context) (bool, error)
+
+	// mu serializes tick and Demand: a cold start must not race the
+	// reconciler's own view of why the engine is down.
+	mu sync.Mutex
+	// idleStopped mirrors the engine-state file; kept in memory so the tick
+	// can tell "down because I idled it" from "down unexpectedly" without
+	// re-reading, and re-adopted from the file after a supervisor restart.
+	idleStopped bool
+	// upSince anchors the idle clock: a freshly started engine with no
+	// traffic yet must age past the timeout before it can be idled.
+	upSince time.Time
+
+	// lastVeto dedupes the "idle stop deferred" log: one line per reason
+	// streak, so a user asking "why is my engine not idling?" gets an answer
+	// without the log drowning in per-tick repeats.
+	lastVeto string
+
 	// failures counts consecutive start failures, for backoff.
 	failures int
 	// nextTry is the earliest moment another start attempt is allowed.
 	nextTry time.Time
+}
+
+// veto records why an idle stop did not happen, logging only when the reason
+// changes. Caller holds s.mu.
+func (s *Supervisor) veto(reason string, kv ...any) {
+	if s.lastVeto == reason {
+		return
+	}
+	s.lastVeto = reason
+	s.log().Info("idle stop deferred", append([]any{"reason", reason}, kv...)...)
 }
 
 func (s *Supervisor) log() *slog.Logger {
@@ -87,11 +137,29 @@ func (s *Supervisor) Run(ctx context.Context) {
 }
 
 func (s *Supervisor) tick(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	desired := ReadDesired(s.Config.StateDir)
 	up := s.Engine.Running(ctx)
 
 	switch {
 	case desired == DesiredRunning && !up:
+		// Down on purpose? The file is the shared truth: this supervisor may
+		// have idled the engine (idleStopped), or a previous incarnation did
+		// (file says idle after a restart) — either way the engine stays down
+		// until demand. Deleting the file is the wake-up poke (`hawser start`
+		// does it), so a set flag with no file means someone asked.
+		fileIdle := ReadEngineState(s.Config.StateDir) == EngineIdle
+		if fileIdle {
+			s.idleStopped = true
+			return // idle by design; Demand or a poke wakes it
+		}
+		if s.idleStopped {
+			s.log().Info("idle marker removed; waking the engine")
+			s.idleStopped = false
+		}
+
 		if time.Now().Before(s.nextTry) {
 			return // still backing off
 		}
@@ -106,6 +174,7 @@ func (s *Supervisor) tick(ctx context.Context) {
 		}
 		s.failures = 0
 		s.nextTry = time.Time{}
+		s.upSince = time.Now()
 		s.log().Info("engine recovered")
 
 	case desired == DesiredStopped && up:
@@ -113,13 +182,112 @@ func (s *Supervisor) tick(ctx context.Context) {
 		if err := s.Engine.Stop(ctx); err != nil {
 			s.log().Error("engine stop failed", "error", err)
 		}
+		s.idleStopped = false
+		WriteEngineState(s.Config.StateDir, EngineActive)
 
 	case desired == DesiredRunning && up:
 		// Healthy: a success observed by the loop also resets backoff, so one
 		// bad patch (a WSL update mid-flight, say) does not tax the next.
 		s.failures = 0
 		s.nextTry = time.Time{}
+		if s.upSince.IsZero() {
+			s.upSince = time.Now()
+		}
+		// A running engine can't be idle-stopped state; clear a stale marker
+		// (someone started the engine by hand while the file said idle).
+		if s.idleStopped || ReadEngineState(s.Config.StateDir) == EngineIdle {
+			s.idleStopped = false
+			WriteEngineState(s.Config.StateDir, EngineActive)
+		}
+		s.maybeIdleStop(ctx)
 	}
+}
+
+// maybeIdleStop stops a healthy engine that nothing is using, returning its
+// RAM to the machine (#41). Caller holds s.mu.
+func (s *Supervisor) maybeIdleStop(ctx context.Context) {
+	if s.Activity == nil || s.IdleTimeout == nil {
+		return
+	}
+	timeout := s.IdleTimeout()
+	if timeout <= 0 {
+		s.lastVeto = ""
+		return // idle stops are off (the default)
+	}
+	if n := s.Activity.ActiveConns(); n > 0 {
+		s.veto("open client connections", "conns", n)
+		return
+	}
+	// The idle clock starts at whichever is later: the last connection, or
+	// the engine coming up — a fresh engine with no traffic yet still gets
+	// its full timeout.
+	quietSince := s.Activity.LastActivity()
+	if s.upSince.After(quietSince) {
+		quietSince = s.upSince
+	}
+	if time.Since(quietSince) < timeout {
+		s.veto("waiting out the quiet window",
+			"quiet", time.Since(quietSince).Round(time.Second), "idleTimeout", timeout)
+		return
+	}
+	// Stopping the engine kills whatever runs in it, so idling requires a
+	// definite "nothing is running": no probe, a probe error, or running
+	// containers all veto.
+	if s.Busy == nil {
+		s.veto("no container probe wired")
+		return
+	}
+	busy, err := s.Busy(ctx)
+	if err != nil {
+		s.veto("container probe failed", "error", err)
+		return
+	}
+	if busy {
+		s.veto("containers are running")
+		return
+	}
+	s.lastVeto = ""
+
+	s.log().Info("bridge quiet and no containers running; stopping the engine until demand",
+		"quiet", time.Since(quietSince).Round(time.Second), "idleTimeout", timeout)
+	if err := WriteEngineState(s.Config.StateDir, EngineIdle); err != nil {
+		s.log().Error("could not record the idle state; leaving the engine running", "error", err)
+		return
+	}
+	if err := s.Engine.Stop(ctx); err != nil {
+		s.log().Error("idle stop failed", "error", err)
+		WriteEngineState(s.Config.StateDir, EngineActive)
+		return
+	}
+	s.idleStopped = true
+}
+
+// Demand wakes an idle-stopped engine for an incoming connection, blocking
+// until it is up; a no-op when the engine is not idle. The pipe server's
+// dialer calls this before every engine dial, so the first `docker` command
+// after an idle stop cold-starts the engine transparently.
+func (s *Supervisor) Demand(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.idleStopped && ReadEngineState(s.Config.StateDir) != EngineIdle {
+		return nil
+	}
+	s.log().Info("connection while idle; cold-starting the engine")
+	began := time.Now()
+	if err := s.Engine.Start(ctx); err != nil {
+		s.log().Error("cold start failed", "error", err)
+		return err
+	}
+	// Cleared only after a successful start, so a second connection arriving
+	// mid-start blocks on the mutex and then sees a running engine, rather
+	// than racing ahead to dial an engine that is not up yet.
+	s.idleStopped = false
+	WriteEngineState(s.Config.StateDir, EngineActive)
+	s.upSince = time.Now()
+	// Measured, not assumed: the issue asked for the real cold-start number.
+	s.log().Info("engine cold-started on demand", "took", time.Since(began).Round(10*time.Millisecond))
+	return nil
 }
 
 // backoff is exponential from 2s, capped: crash loops must not hammer WSL,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -79,6 +80,7 @@ func TestAcceptance(t *testing.T) {
 		{"ExecInRunningContainer", stageExec},
 		{"LogsFollowStreams", stageLogsFollow},
 		{"ComposeStack", stageCompose},
+		{"IdleStopAndOnDemandWake", stageIdle},
 		{"InterruptedClientDoesNotWedgeBridge", stageInterrupt},
 		{"VsockPathServedEverything", stageVsockServed},
 		{"Uninstall", stageUninstall},
@@ -214,15 +216,19 @@ func stageProxy(t *testing.T, s *state) {
 	}
 	s.proxyLog = f
 
-	// The suite's own pipe, so a Hawser or Docker Desktop already on the
-	// machine is neither disturbed nor accidentally tested.
-	s.proxy = exec.Command(s.hawser, "proxy",
+	// The bridge is `hawser supervise`, not `hawser proxy`: it is what real
+	// installs run (autostart launches it), and it is where the idle/on-demand
+	// behavior the IdleStop stage exercises lives. The suite's own pipe and
+	// state dir keep a Hawser or Docker Desktop already on the machine
+	// undisturbed — the state dir also scopes the supervisor's single-instance
+	// mutex, so a real supervisor can coexist with the suite's.
+	s.proxy = exec.Command(s.hawser, "supervise",
 		"--distro", distro, "--state-dir", s.stateDir,
 		"--pipe", pipeName, "--no-context")
 	s.proxy.Stdout = f
 	s.proxy.Stderr = f
 	if err := s.proxy.Start(); err != nil {
-		t.Fatalf("starting proxy: %v", err)
+		t.Fatalf("starting supervisor: %v", err)
 	}
 
 	// Up when the engine answers, not when the process exists.
@@ -390,6 +396,71 @@ services:
 	}
 	if !strings.Contains(string(got), "compose-ran") {
 		t.Errorf("output.txt = %q", got)
+	}
+}
+
+func stageIdle(t *testing.T, s *state) {
+	// The #41 story end to end: configure a short idle timeout, watch the
+	// supervisor stop the quiet engine (status says idle, exit 0 — "stopped
+	// by design" is not an error), then have one docker command wake it.
+	out, err := run(t, 30*time.Second, s.hawser, "config",
+		"--state-dir", s.stateDir, "set", "idle-timeout", "15s")
+	must(t, out, err, "hawser config set idle-timeout")
+	defer func() {
+		out, err := run(t, 30*time.Second, s.hawser, "config",
+			"--state-dir", s.stateDir, "set", "idle-timeout", "off")
+		must(t, out, err, "hawser config set idle-timeout off")
+	}()
+
+	statusJSON := func() (engine string, exit int) {
+		t.Helper()
+		out, err := run(t, 30*time.Second, s.hawser, "status", "--state-dir", s.stateDir, "--json")
+		if err != nil {
+			return "", 1
+		}
+		var st struct {
+			Engine string `json:"engine"`
+		}
+		if jerr := json.Unmarshal([]byte(out), &st); jerr != nil {
+			t.Fatalf("status --json unparseable: %v\n%s", jerr, out)
+		}
+		return st.Engine, 0
+	}
+
+	// Idle within: 15s quiet + a few 3s ticks + the stop itself.
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		engine, _ := statusJSON()
+		if engine == "idle" {
+			break
+		}
+		if time.Now().After(deadline) {
+			// The supervisor logs why each idle stop was deferred; that tail
+			// is the diagnosis.
+			logBytes, _ := os.ReadFile(filepath.Join(s.stateDir, "proxy-e2e.log"))
+			tail := string(logBytes)
+			if len(tail) > 4000 {
+				tail = tail[len(tail)-4000:]
+			}
+			t.Fatalf("engine did not idle-stop within 90s; status reports %q\nsupervisor log tail:\n%s", engine, tail)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Log("engine idle-stopped; status reports it as such")
+
+	// `hawser status` must treat idle as healthy: exit 0.
+	if out, err := run(t, 30*time.Second, s.hawser, "status", "--state-dir", s.stateDir); err != nil {
+		t.Errorf("status exited non-zero on an idle engine (stopped by design is not broken):\n%s", out)
+	}
+
+	// One docker command is the wake-up: it pays the cold start and works.
+	began := time.Now()
+	out, err = dockerE(t, s, 2*time.Minute, "version", "--format", "{{.Server.Version}}")
+	must(t, out, err, "docker version against an idle engine")
+	t.Logf("cold start: docker version answered %q in %s", out, time.Since(began).Round(100*time.Millisecond))
+
+	if engine, _ := statusJSON(); engine != "running" {
+		t.Errorf("engine is %q after the on-demand wake, want running", engine)
 	}
 }
 


### PR DESCRIPTION
S3 of the v0.2 plan — the idle-RAM answer. Closes #41.

## What

- **`hawser config list|get|set`** with `idle-timeout` as the first key: state-dir `config.json`, validated on the way in (unknown keys refused, durations normalized, 10s floor, `off` default), read fresh at each use so `set` applies live without restarting anything.
- **Idle stop**: with a timeout set, a healthy engine that has had **no open client connections** for the timeout AND **verifiably no running containers** (probed over the engine API through the bridge''s own transport; no probe / probe error / running containers all veto — stopping the engine kills what runs in it) is stopped until demand. Never `wsl --shutdown`; only our own distro. Vetoes log once per reason streak, so "why is my engine not idling?" has an answer in the log.
- **On-demand start**: the pipe server''s dialer wakes an idle engine before dialing — the first docker command after an idle stop cold-starts it transparently; a second connection arriving mid-start blocks until the engine is up. **Measured**: 820ms engine start, 3.2s end-to-end `docker version`.
- **`hawser status`**: engine reports `idle` with exit 0 — "stopped by design" is distinguishable from broken, per the issue. The `engine-state` file records why the engine is down (distinct from the user''s desired state); deleting it is the wake poke (`hawser start` does), and a restarted supervisor adopts it rather than "repairing" the down engine.

## Bug found by building this (first commit)

The idle veto instrumentation exposed a **relay leak present since v0.1**: `docker compose` subscribes to `/events`; after `compose down` the stream is quiet, and when the CLI exits the relay — blocked reading the silent engine side — never notices the dead client. The connection pinned the bridge open forever (same half-open class as #35, new surface). `RewriteBinds` now watches the client with a concurrent `Peek` while a response streams (which also serializes reads between keep-alive requests). Regression test hangs without the fix.

## Testing

- Unit: all packages; new config round-trip/validation suite and 9 idle-machinery tests (vetoes, adoption after supervisor restart, stale-marker cleanup, demand no-op vs cold start, wake-by-poke).
- Acceptance: suite''s bridge switched from `hawser proxy` to **`hawser supervise`** (what real installs run), plus a live `IdleStopAndOnDemandWake` stage: set 15s timeout → engine idle-stops → status contract holds → one docker command wakes it. **15 stages green in 59s.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)