### PR TITLE
hawser wsl-integrate: share the engine into the user's WSL distros

### DIFF
--- a/cmd/hawser/install.go
+++ b/cmd/hawser/install.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/zcsizmadia/hawser/internal/autostart"
 	"github.com/zcsizmadia/hawser/internal/dockerctx"
+	"github.com/zcsizmadia/hawser/internal/integrate"
 	"github.com/zcsizmadia/hawser/internal/logging"
 	"github.com/zcsizmadia/hawser/internal/pipeproxy"
 	"github.com/zcsizmadia/hawser/internal/provision"
 	"github.com/zcsizmadia/hawser/internal/release"
+	"github.com/zcsizmadia/hawser/internal/wsl"
 )
 
 // cliLogger prints progress as plain lines rather than structured logfmt: this
@@ -281,6 +283,10 @@ flags:
 	if err := logging.UnregisterEventSource(); err != nil {
 		log.Debug("event log source not unregistered (needs elevation; cosmetic)", "error", err)
 	}
+
+	// Unwire every distro wsl-integrate touched: "nothing else on the system
+	// was modified" must include profile scripts in the user's own distros.
+	(&integrate.Manager{WSL: &wsl.Local{}, StateDir: opts.StateDir, Logger: log}).RemoveAll(ctx)
 
 	// Remove the context before the distro: leaving a context pointed at a
 	// pipe nobody serves would make every later docker command fail, which is

--- a/cmd/hawser/integrate.go
+++ b/cmd/hawser/integrate.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/zcsizmadia/hawser/internal/integrate"
+	"github.com/zcsizmadia/hawser/internal/provision"
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+func runWSLIntegrate(args []string) int {
+	fs := flag.NewFlagSet("wsl-integrate", flag.ContinueOnError)
+	var (
+		stateDir = fs.String("state-dir", "", "override Hawser's state directory")
+		remove   = fs.Bool("remove", false, "unwire the distro instead")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `usage: hawser wsl-integrate <distro>       wire a distro to the engine
+       hawser wsl-integrate --remove <distro>
+       hawser wsl-integrate                without arguments: list wired distros
+
+Points docker inside one of your own WSL distros at the Hawser engine, by
+writing %s there (DOCKER_HOST to the engine socket shared at /mnt/wsl). Takes
+effect in new login shells. Never touches a distro you did not name, and
+`+"`hawser uninstall`"+` unwires everything it wired.
+
+Note: with an idle-timeout configured, traffic through the shared socket does
+not count as bridge activity and cannot wake an idle-stopped engine — keep
+idle-timeout off, or run `+"`hawser start`"+` first, when working in-distro.
+
+Exit codes: 0 ok, %d error, %d usage.
+`, integrate.ProfilePath, exitError, exitUsage)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	opts := optsWithResolvedStateDir(provision.Options{StateDir: *stateDir})
+	log := cliLogger(false)
+	m := &integrate.Manager{WSL: &wsl.Local{}, StateDir: opts.StateDir, Logger: log}
+
+	rest := fs.Args()
+	if len(rest) == 0 && !*remove {
+		wired, err := m.List()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		if len(wired) == 0 {
+			fmt.Println("no distros wired; `hawser wsl-integrate <distro>` wires one")
+			return exitOK
+		}
+		for _, d := range wired {
+			fmt.Println(d)
+		}
+		return exitOK
+	}
+	if len(rest) != 1 {
+		fs.Usage()
+		return exitUsage
+	}
+	target := rest[0]
+	ctx := context.Background()
+
+	if *remove {
+		if err := m.Remove(ctx, target); err != nil {
+			fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+			return exitError
+		}
+		fmt.Printf("%s unwired; open a new shell there for it to take effect\n", target)
+		return exitOK
+	}
+
+	p := &provision.Provisioner{Logger: log}
+	engineDistro, ok := resolveDistro(p, opts)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "hawser: no install found. Run `hawser install` first.")
+		return exitNotFound
+	}
+	if err := m.Integrate(ctx, target, engineDistro,
+		provision.SharedSocketPath(engineDistro)); err != nil {
+		fmt.Fprintf(os.Stderr, "hawser: %v\n", err)
+		return exitError
+	}
+	fmt.Printf(`%s wired to the Hawser engine.
+
+Open a new shell in it and docker just works:
+
+  wsl -d %s
+  docker ps
+
+Undo anytime with: hawser wsl-integrate --remove %s
+`, target, target, target)
+	return exitOK
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -37,6 +37,7 @@ func commands() []command {
 		{"stop", "stop the engine; it stays stopped until start", runStop},
 		{"supervise", "serve the pipe and keep the engine alive (the always-on layer)", runSupervise},
 		{"uninstall", "remove the engine distro and Hawser's state", runUninstall},
+		{"wsl-integrate", "point docker inside your own WSL distros at the engine", runWSLIntegrate},
 		{"version", "report every component version and which docker.exe is active", runVersion},
 	}
 }

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -1,0 +1,187 @@
+// Package integrate shares the Hawser engine into the user's own WSL distros
+// (#42): Desktop parity for people whose workflow lives inside a distro.
+//
+// The transport is the /mnt/wsl bind mount the provisioner publishes
+// (provision.SharedSocketPath); this package only wires the target distro's
+// environment to it, via a profile.d script. Consent is the command itself —
+// nothing here runs unless the user asked for that specific distro — and
+// every integration is recorded so `hawser uninstall` can reverse it.
+package integrate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// ProfilePath is the script written inside a target distro. profile.d keeps
+// it out of the user's own dotfiles and makes removal a single rm.
+const ProfilePath = "/etc/profile.d/hawser.sh"
+
+// Manager wires and unwires distros.
+type Manager struct {
+	// WSL runs commands in distros. Required.
+	WSL wsl.WSL
+	// StateDir is where integrations are recorded. Required.
+	StateDir string
+	// Logger defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+func (m *Manager) log() *slog.Logger {
+	if m.Logger != nil {
+		return m.Logger
+	}
+	return slog.Default()
+}
+
+func (m *Manager) recordPath() string {
+	return filepath.Join(m.StateDir, "integrations.json")
+}
+
+// Integrate wires DOCKER_HOST inside target to the engine's shared socket.
+func (m *Manager) Integrate(ctx context.Context, target, engineDistro, socketPath string) error {
+	if target == engineDistro {
+		return fmt.Errorf("%q is the engine distro itself; it talks to its own socket already", target)
+	}
+	if err := m.distroExists(ctx, target); err != nil {
+		return err
+	}
+
+	// The script announces its origin and its undo, because the person who
+	// finds it in six months may not be the person who ran the command.
+	content := fmt.Sprintf(
+		"# Written by `hawser wsl-integrate %s`; remove with `hawser wsl-integrate --remove %s`.\n"+
+			"# Points docker at the Hawser engine shared from the %s distro.\n"+
+			`export DOCKER_HOST="unix://%s"`+"\n",
+		target, target, engineDistro, socketPath)
+
+	// Content travels as a positional parameter — never spliced into the
+	// script — so nothing in it can become shell.
+	if _, err := m.WSL.Exec(ctx, target, "root",
+		"sh", "-c", `printf '%s' "$1" > `+ProfilePath, "sh", content); err != nil {
+		return fmt.Errorf("writing %s in %s: %w", ProfilePath, target, err)
+	}
+
+	if err := m.record(target, true); err != nil {
+		return err
+	}
+	m.log().Info("distro integrated", "distro", target, "socket", socketPath)
+	return nil
+}
+
+// Remove unwires a distro. A distro that is already clean — or no longer
+// exists — counts as success: the user asked for a state, not an action.
+func (m *Manager) Remove(ctx context.Context, target string) error {
+	if err := m.distroExists(ctx, target); err == nil {
+		if _, err := m.WSL.Exec(ctx, target, "root", "rm", "-f", ProfilePath); err != nil {
+			return fmt.Errorf("removing %s from %s: %w", ProfilePath, target, err)
+		}
+	} else {
+		m.log().Info("distro no longer exists; unrecording only", "distro", target)
+	}
+	if err := m.record(target, false); err != nil {
+		return err
+	}
+	m.log().Info("distro integration removed", "distro", target)
+	return nil
+}
+
+// List returns the recorded integrations, sorted.
+func (m *Manager) List() ([]string, error) {
+	set, err := m.load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// RemoveAll unwires every recorded distro, best-effort, for uninstall.
+func (m *Manager) RemoveAll(ctx context.Context) {
+	distros, err := m.List()
+	if err != nil {
+		m.log().Warn("could not read integrations; profile scripts may remain", "error", err)
+		return
+	}
+	for _, d := range distros {
+		if err := m.Remove(ctx, d); err != nil {
+			m.log().Warn("could not unwire distro", "distro", d, "error", err)
+		}
+	}
+}
+
+func (m *Manager) distroExists(ctx context.Context, target string) error {
+	distros, err := m.WSL.List(ctx)
+	if err != nil {
+		return fmt.Errorf("listing distros: %w", err)
+	}
+	names := make([]string, 0, len(distros))
+	for _, d := range distros {
+		if d.Name == target {
+			return nil
+		}
+		names = append(names, d.Name)
+	}
+	return fmt.Errorf("no WSL distro named %q (have: %s)", target, strings.Join(names, ", "))
+}
+
+func (m *Manager) load() (map[string]bool, error) {
+	set := map[string]bool{}
+	b, err := os.ReadFile(m.recordPath())
+	if os.IsNotExist(err) {
+		return set, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading integrations: %w", err)
+	}
+	var list []string
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", m.recordPath(), err)
+	}
+	for _, d := range list {
+		set[d] = true
+	}
+	return set, nil
+}
+
+func (m *Manager) record(target string, present bool) error {
+	set, err := m.load()
+	if err != nil {
+		return err
+	}
+	if present {
+		set[target] = true
+	} else {
+		delete(set, target)
+	}
+	list := make([]string, 0, len(set))
+	for d := range set {
+		list = append(list, d)
+	}
+	sort.Strings(list)
+
+	if err := os.MkdirAll(m.StateDir, 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	b, _ := json.MarshalIndent(list, "", "  ")
+	tmp := m.recordPath() + ".tmp"
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("recording integration: %w", err)
+	}
+	if err := os.Rename(tmp, m.recordPath()); err != nil {
+		return fmt.Errorf("committing integration record: %w", err)
+	}
+	return nil
+}

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -1,0 +1,146 @@
+package integrate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zcsizmadia/hawser/internal/wsl"
+)
+
+// fakeWSL records Execs and serves a fixed distro list.
+type fakeWSL struct {
+	wsl.WSL // panic on anything not overridden
+
+	mu      sync.Mutex
+	distros []wsl.Distro
+	execs   [][]string
+	execErr error
+}
+
+func (f *fakeWSL) List(context.Context) ([]wsl.Distro, error) {
+	return f.distros, nil
+}
+
+func (f *fakeWSL) Exec(_ context.Context, distro, user string, args ...string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execs = append(f.execs, append([]string{distro, user}, args...))
+	return "", f.execErr
+}
+
+func quiet() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func manager(t *testing.T, distros ...string) (*Manager, *fakeWSL) {
+	t.Helper()
+	f := &fakeWSL{}
+	for _, d := range distros {
+		f.distros = append(f.distros, wsl.Distro{Name: d, Version: 2})
+	}
+	return &Manager{WSL: f, StateDir: t.TempDir(), Logger: quiet()}, f
+}
+
+func TestIntegrateWritesProfileAndRecords(t *testing.T) {
+	m, f := manager(t, "Ubuntu", "hawser-engine")
+
+	if err := m.Integrate(context.Background(), "Ubuntu", "hawser-engine",
+		"/mnt/wsl/hawser-engine/docker.sock"); err != nil {
+		t.Fatalf("Integrate: %v", err)
+	}
+
+	if len(f.execs) != 1 {
+		t.Fatalf("%d execs, want 1", len(f.execs))
+	}
+	joined := strings.Join(f.execs[0], " ")
+	if f.execs[0][0] != "Ubuntu" || f.execs[0][1] != "root" {
+		t.Errorf("exec targeted %s as %s", f.execs[0][0], f.execs[0][1])
+	}
+	if !strings.Contains(joined, ProfilePath) {
+		t.Errorf("exec does not write %s: %s", ProfilePath, joined)
+	}
+	// The export travels as a positional parameter, not spliced into the
+	// script — and names the socket.
+	if !strings.Contains(joined, `DOCKER_HOST="unix:///mnt/wsl/hawser-engine/docker.sock"`) {
+		t.Errorf("profile content missing the DOCKER_HOST export: %s", joined)
+	}
+
+	got, err := m.List()
+	if err != nil || len(got) != 1 || got[0] != "Ubuntu" {
+		t.Errorf("List = %v, %v; want [Ubuntu]", got, err)
+	}
+}
+
+func TestIntegrateRefusesEngineDistro(t *testing.T) {
+	m, f := manager(t, "hawser-engine")
+	if err := m.Integrate(context.Background(), "hawser-engine", "hawser-engine", "/s"); err == nil {
+		t.Fatal("integrated the engine distro into itself")
+	}
+	if len(f.execs) != 0 {
+		t.Error("a refused integrate still ran commands")
+	}
+}
+
+func TestIntegrateRefusesUnknownDistro(t *testing.T) {
+	m, _ := manager(t, "Ubuntu")
+	err := m.Integrate(context.Background(), "Debain", "hawser-engine", "/s")
+	if err == nil {
+		t.Fatal("integrated a distro that does not exist")
+	}
+	// The error should help with the typo.
+	if !strings.Contains(err.Error(), "Ubuntu") {
+		t.Errorf("error does not list existing distros: %v", err)
+	}
+}
+
+func TestRemoveUnwiresAndUnrecords(t *testing.T) {
+	m, f := manager(t, "Ubuntu", "hawser-engine")
+	if err := m.Integrate(context.Background(), "Ubuntu", "hawser-engine", "/s"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Remove(context.Background(), "Ubuntu"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	last := strings.Join(f.execs[len(f.execs)-1], " ")
+	if !strings.Contains(last, "rm -f "+ProfilePath) {
+		t.Errorf("remove did not delete the profile script: %s", last)
+	}
+	if got, _ := m.List(); len(got) != 0 {
+		t.Errorf("List after Remove = %v, want empty", got)
+	}
+}
+
+func TestRemoveVanishedDistroUnrecords(t *testing.T) {
+	// The distro was integrated and later deleted by the user; uninstall must
+	// still come clean instead of failing on it.
+	m, f := manager(t, "Ubuntu", "hawser-engine")
+	if err := m.Integrate(context.Background(), "Ubuntu", "hawser-engine", "/s"); err != nil {
+		t.Fatal(err)
+	}
+	f.distros = f.distros[1:] // Ubuntu is gone
+
+	if err := m.Remove(context.Background(), "Ubuntu"); err != nil {
+		t.Fatalf("Remove of vanished distro: %v", err)
+	}
+	if got, _ := m.List(); len(got) != 0 {
+		t.Errorf("List = %v, want empty", got)
+	}
+}
+
+func TestRemoveAllBestEffort(t *testing.T) {
+	m, f := manager(t, "Ubuntu", "Debian", "hawser-engine")
+	m.Integrate(context.Background(), "Ubuntu", "hawser-engine", "/s")
+	m.Integrate(context.Background(), "Debian", "hawser-engine", "/s")
+
+	f.execErr = errors.New("distro broken")
+	m.RemoveAll(context.Background()) // must not panic or stop at the first failure
+
+	f.execErr = nil
+	m.RemoveAll(context.Background())
+	if got, _ := m.List(); len(got) != 0 {
+		t.Errorf("List after RemoveAll = %v, want empty", got)
+	}
+}

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -217,10 +217,11 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 
 	if running, _ := p.engineRunning(ctx, opts); running {
 		p.logger().Info("engine already running", "distro", opts.Distro)
-		// The agent's lifetime is not tied to dockerd's: a supervisor that
-		// finds a healthy engine (its own restart, say) must still make sure
-		// the vsock path is up.
+		// Neither the agent nor the socket share is tied to dockerd's
+		// lifetime: a supervisor that finds a healthy engine (its own
+		// restart, say) must still make sure both are up.
 		p.startAgent(ctx, opts)
+		p.shareEngineSocket(ctx, opts)
 		return nil
 	}
 
@@ -237,6 +238,10 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 	for time.Now().Before(deadline) {
 		if running, _ := p.engineRunning(ctx, opts); running {
 			p.logger().Info("engine socket is up", "distro", opts.Distro)
+			// Shared only once the socket exists: a bind mount of a missing
+			// file cannot be made, and the share is re-done on every start
+			// because the previous engine's bind went stale with it.
+			p.shareEngineSocket(ctx, opts)
 			return nil
 		}
 		select {
@@ -250,6 +255,43 @@ func (p *Provisioner) StartEngine(ctx context.Context, opts Options) error {
 	log, _ := p.wsl().Exec(ctx, opts.Distro, "root", "tail", "-30", "/var/log/dockerd.log")
 	return fmt.Errorf("dockerd did not create %s within %s. Last log lines:\n%s",
 		EngineSocket, opts.StartTimeout, log)
+}
+
+// SharedSocketPath is where the engine socket is bind-mounted for other WSL
+// distros (#42): /mnt/wsl is a tmpfs shared VM-wide across every distro, and a
+// bind mount of the socket file shares the live inode, which a symlink cannot
+// (it would resolve in the reader's own namespace, where /var/run/docker.sock
+// does not exist). Namespaced by distro name so a second install — the e2e
+// suite runs one beside a real install — shares its own socket, not a
+// collision.
+func SharedSocketPath(distro string) string {
+	return "/mnt/wsl/" + distro + "/docker.sock"
+}
+
+// shareEngineSocket publishes the engine socket at SharedSocketPath,
+// best-effort: sharing is Desktop-parity plumbing for wsl-integrate, and its
+// failure must not fail an engine start. The path travels as a positional
+// parameter, never spliced into the script, so a hostile distro name cannot
+// inject shell. A stale share from a previous engine run (the bind outlives
+// the distro in the VM's tmpfs) is unmounted first.
+//
+// The socket is chmod'd 0666 so the *ordinary* user in an integrated distro
+// can reach it — dockerd creates it 0660 root:root, and UIDs/groups do not
+// map reliably across distros, so group-based access is unreliable where a
+// world bit is not. This does not widen the trust boundary: the engine is
+// already reachable by any process in the user's Windows session through the
+// named pipe, and /mnt/wsl is shared only among that user's own distros in
+// their own utility VM. chmod targets the shared inode, so the engine's own
+// /var/run/docker.sock (which only root touches inside the engine distro) is
+// affected too, which is immaterial there.
+func (p *Provisioner) shareEngineSocket(ctx context.Context, opts Options) {
+	const script = `dir=$(dirname "$1") && mkdir -p "$dir" && ` +
+		`{ umount "$1" 2>/dev/null || true; } && rm -f "$1" && touch "$1" && ` +
+		`mount --bind /var/run/docker.sock "$1" && chmod 0666 "$1"`
+	if _, err := p.wsl().Exec(ctx, opts.Distro, "root",
+		"sh", "-c", script, "sh", SharedSocketPath(opts.Distro)); err != nil {
+		p.logger().Debug("engine socket not shared to /mnt/wsl", "error", err)
+	}
 }
 
 // agentStartCmd is what launches hawser-agent (#40), guarded three ways: a
@@ -305,6 +347,14 @@ func (p *Provisioner) Uninstall(ctx context.Context, opts Options) error {
 	}
 
 	if registered {
+		// Clear the /mnt/wsl share first, while the distro can still run a
+		// command: after unregister the dead socket file would sit in the
+		// VM's shared tmpfs until the next VM restart. Best-effort — a
+		// stopped distro would be booted just to clean a tmpfs entry.
+		const unshare = `umount "$1" 2>/dev/null; rm -rf "$(dirname "$1")"`
+		p.wsl().Exec(ctx, opts.Distro, "root",
+			"sh", "-c", unshare, "sh", SharedSocketPath(opts.Distro))
+
 		p.logger().Info("terminating distro", "distro", opts.Distro)
 		if err := p.wsl().Terminate(ctx, opts.Distro); err != nil {
 			// Not fatal: unregister stops it anyway.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -80,6 +80,7 @@ func TestAcceptance(t *testing.T) {
 		{"ExecInRunningContainer", stageExec},
 		{"LogsFollowStreams", stageLogsFollow},
 		{"ComposeStack", stageCompose},
+		{"WSLIntegrateSharesEngine", stageWSLIntegrate},
 		{"IdleStopAndOnDemandWake", stageIdle},
 		{"InterruptedClientDoesNotWedgeBridge", stageInterrupt},
 		{"VsockPathServedEverything", stageVsockServed},
@@ -461,6 +462,60 @@ func stageIdle(t *testing.T, s *state) {
 
 	if engine, _ := statusJSON(); engine != "running" {
 		t.Errorf("engine is %q after the on-demand wake, want running", engine)
+	}
+}
+
+func stageWSLIntegrate(t *testing.T, s *state) {
+	// #42 end to end, against a real second distro: the engine socket is
+	// shared VM-wide at /mnt/wsl/<distro>/docker.sock, wsl-integrate wires a
+	// target distro's DOCKER_HOST to it, --remove unwires cleanly.
+	list, _ := run(t, 30*time.Second, "wsl.exe", "--list", "--quiet")
+	if !strings.Contains(strings.ReplaceAll(list, "\x00", ""), "Ubuntu") {
+		t.Skip("no Ubuntu distro to integrate against")
+	}
+	// Never clobber a real integration: if the user's Ubuntu already carries
+	// the profile script, this stage's --remove would delete theirs.
+	if _, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu",
+		"--", "test", "-f", "/etc/profile.d/hawser.sh"); err == nil {
+		t.Skip("Ubuntu already has a hawser integration; not touching it")
+	}
+
+	// The engine's socket must be visible from the OTHER distro — that is
+	// the whole point of the /mnt/wsl bind.
+	sock := "/mnt/wsl/" + distro + "/docker.sock"
+	if out, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu",
+		"--", "test", "-S", sock); err != nil {
+		t.Fatalf("shared socket %s not visible from Ubuntu: %v\n%s", sock, err, out)
+	}
+	// And it must actually answer, as the ORDINARY user (not root): the point
+	// of the share is docker-without-sudo, which needs the 0666 the
+	// provisioner sets. A dead inode also passes test -S, so this is the real
+	// check. Skip only when curl is genuinely absent (exit 127), not when it
+	// runs and fails.
+	if _, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu", "--", "sh", "-c", "command -v curl"); err != nil {
+		t.Log("curl absent in Ubuntu; socket presence checked but not exercised")
+	} else {
+		out, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu", "--",
+			"curl", "-s", "--max-time", "10", "--unix-socket", sock, "http://localhost/_ping")
+		if err != nil || out != "OK" {
+			t.Errorf("engine ping from Ubuntu as the ordinary user = %q (%v); want OK — the shared socket must be user-accessible, not root-only", out, err)
+		}
+	}
+
+	out, err := run(t, time.Minute, s.hawser, "wsl-integrate", "--state-dir", s.stateDir, "Ubuntu")
+	must(t, out, err, "hawser wsl-integrate Ubuntu")
+	defer run(t, time.Minute, s.hawser, "wsl-integrate", "--state-dir", s.stateDir, "--remove", "Ubuntu")
+
+	if out, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu",
+		"--", "cat", "/etc/profile.d/hawser.sh"); err != nil || !strings.Contains(out, sock) {
+		t.Errorf("profile script wrong or missing (%v):\n%s", err, out)
+	}
+
+	out, err = run(t, time.Minute, s.hawser, "wsl-integrate", "--state-dir", s.stateDir, "--remove", "Ubuntu")
+	must(t, out, err, "hawser wsl-integrate --remove")
+	if _, err := run(t, 30*time.Second, "wsl.exe", "-d", "Ubuntu",
+		"--", "test", "-f", "/etc/profile.d/hawser.sh"); err == nil {
+		t.Error("profile script still present after --remove")
 	}
 }
 


### PR DESCRIPTION
S3 of the v0.2 plan — Desktop parity for people whose workflow lives inside their own WSL distro. Closes #42.

## What

- **Transport**: the provisioner bind-mounts the engine socket to `/mnt/wsl/<distro>/docker.sock` on every engine start. `/mnt/wsl` is a tmpfs shared VM-wide across all the user''s distros; a bind shares the live inode (a symlink can''t — it resolves in the reader''s namespace). The socket is chmod''d **0666** so the *ordinary* user in a target distro can reach it (dockerd makes it 0660 root:root; UIDs/groups don''t map across distros). This doesn''t widen the trust boundary: the engine is already reachable by any process in the user''s Windows session via the named pipe, and `/mnt/wsl` is private to that user''s own utility VM. Re-made each start (goes stale with the distro), torn down on uninstall.
- **`hawser wsl-integrate <distro>`** writes `/etc/profile.d/hawser.sh` in the target (DOCKER_HOST → shared socket), with origin and undo named in the file. Refuses the engine distro and unknown names (listing real ones for a typo). `--remove` unwires; bare command lists; a vanished target still unrecords so uninstall stays clean. Recorded in state and reversed en masse by uninstall.

## Found while building it

The socket dockerd creates is `0660 root:root` — so the ordinary user got connection-refused. That defeats the feature''s point (docker without sudo), hence the 0666 + the rationale above. Caught because the first e2e run''s curl check degraded to presence-only; the stage now **requires** the ordinary-user ping to return OK.

## Verified live

A login shell in Ubuntu gets `DOCKER_HOST` from the profile and `docker version` answers 29.7.2 over the shared socket **as the ordinary user** (proven not-Desktop via explicit `-H`); `--remove` leaves the env clean.

Unit: 6 integrate tests (profile write, engine-distro/unknown-distro refusal, remove, vanished-distro, best-effort RemoveAll). Acceptance: **16 stages, 61s**, new WSLIntegrateSharesEngine stage against the real Ubuntu distro (skips safely if it already has a real integration).

One documented limitation (in `--help`): traffic through the shared socket doesn''t count as bridge activity for idle detection, so with idle-timeout set, run `hawser start` first when working in-distro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)