### PR TITLE
Serve the pipe in message mode: fix docker run -i / exec -i hang

### DIFF
--- a/internal/pipeproxy/listen_windows.go
+++ b/internal/pipeproxy/listen_windows.go
@@ -45,10 +45,22 @@ func Listen(pipeName, sddl string) (net.Listener, error) {
 
 	l, err := winio.ListenPipe(pipeName, &winio.PipeConfig{
 		SecurityDescriptor: sddl,
-		// The engine API carries large payloads (image push/pull, build
-		// contexts); message mode would frame them wrongly. Byte mode is what
-		// dockerd's own Windows listener uses.
-		MessageMode: false,
+		// Message mode, for one specific reason: it is the only way a named
+		// pipe can carry a half-close. The docker CLI signals stdin-EOF on a
+		// hijacked interactive stream (docker run -i, exec -i, a pipe into a
+		// container) by calling CloseWrite on its connection; on a byte-mode
+		// winio pipe that is a silent no-op, so the container's stdin never
+		// ends and the command hangs forever (#57). In message mode winio
+		// implements CloseWrite as a zero-byte message the reader surfaces as
+		// io.EOF — which the relay already propagates to the engine.
+		//
+		// This does NOT reframe large payloads: winio presents a message-mode
+		// pipe as a byte stream for ordinary reads (it swallows
+		// ERROR_MORE_DATA), and a zero-length data write sends nothing, so
+		// only an explicit CloseWrite ever signals EOF. Image pull/push,
+		// build contexts and every hijack path are exercised by the
+		// acceptance suite under this mode.
+		MessageMode: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("pipeproxy: listen %s: %w", pipeName, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -78,6 +78,7 @@ func TestAcceptance(t *testing.T) {
 		{"HelloWorld", stageHelloWorld},
 		{"BindMountReadThroughContainer", stageBindMount},
 		{"ExecInRunningContainer", stageExec},
+		{"StdinPipeIntoContainer", stageStdinPipe},
 		{"LogsFollowStreams", stageLogsFollow},
 		{"ComposeStack", stageCompose},
 		{"WSLIntegrateSharesEngine", stageWSLIntegrate},
@@ -311,6 +312,59 @@ func stageExec(t *testing.T, s *state) {
 	// A real interactive TTY (exec -it, Ctrl-C on logs -f) cannot be driven
 	// from a test binary without a ConPTY harness; that stays the documented
 	// manual check from #11.
+}
+
+func stageStdinPipe(t *testing.T, s *state) {
+	// #57: piping into an interactive container must return, not hang. The CLI
+	// signals stdin-EOF by half-closing its named-pipe connection, which only
+	// works because the bridge serves the pipe in message mode; a byte-mode
+	// pipe swallows the CloseWrite and the container blocks on stdin forever.
+	// The bounded timeout in dockerStdin turns a regression into a failure
+	// rather than a hung suite.
+	const payload = "line-one\nline-two\nline-three\n"
+
+	got, err := dockerStdin(t, s, payload, 45*time.Second, "run", "-i", "--rm", "alpine:latest", "cat")
+	must(t, got, err, "docker run -i cat (stdin round-trip)")
+	if got != strings.TrimRight(payload, "\n") {
+		t.Errorf("run -i cat returned %q, want the piped payload", got)
+	}
+
+	// exec -i into a running container is the same half-close path.
+	if out, err := dockerE(t, s, 2*time.Minute, "run", "-d", "--name", "e2e-stdin",
+		"alpine:latest", "sleep", "300"); err != nil {
+		t.Fatalf("starting container: %v\n%s", err, out)
+	}
+	defer dockerE(t, s, time.Minute, "rm", "-f", "e2e-stdin")
+
+	got, err = dockerStdin(t, s, payload, 45*time.Second, "exec", "-i", "e2e-stdin", "wc", "-l")
+	must(t, got, err, "docker exec -i wc -l (stdin round-trip)")
+	if strings.TrimSpace(got) != "3" {
+		t.Errorf("exec -i wc -l counted %q lines, want 3 (stdin EOF did not propagate)", got)
+	}
+}
+
+// dockerStdin runs docker against the suite's engine with a string on stdin,
+// bounded by timeout so a stdin-EOF regression fails instead of hanging.
+func dockerStdin(t *testing.T, s *state, stdin string, timeout time.Duration, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(s.docker, args...)
+	cmd.Env = s.dockerEnv()
+	cmd.Stdin = strings.NewReader(stdin)
+	done := make(chan struct{})
+	var out []byte
+	var err error
+	go func() { out, err = cmd.CombinedOutput(); close(done) }()
+	select {
+	case <-done:
+		return strings.TrimSpace(string(out)), err
+	case <-time.After(timeout):
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+		<-done
+		return strings.TrimSpace(string(out)), fmt.Errorf("docker %s timed out after %s (stdin EOF likely not propagating)",
+			strings.Join(args, " "), timeout)
+	}
 }
 
 func stageLogsFollow(t *testing.T, s *state) {


### PR DESCRIPTION
Closes #57. Piping into an interactive container hung forever through the bridge; this fixes it.

## Root cause

The docker CLI signals stdin-EOF on a hijacked interactive stream (`docker run -i`, `exec -i`) by calling `CloseWrite` on its connection. Over a **byte-mode** winio named pipe that''s a silent no-op, so the client''s half-close never reached the bridge, the relay never closed the engine side''s write half, and the container''s stdin never ended. The break is at the CLI↔pipe hop — upstream of the vsock relay, which already propagates CloseWrite.

## Fix

Serve the pipe in **message mode** (`internal/pipeproxy` listener). winio implements `CloseWrite` there as a zero-byte message the reader surfaces as `io.EOF`, and the relay''s existing client→engine EOF handling propagates it to the engine.

This does **not** reframe large payloads: winio presents a message-mode pipe as a byte stream for ordinary reads (ERROR_MORE_DATA is swallowed), and a zero-length data write sends nothing, so only an explicit CloseWrite ever signals EOF. The client gets a CloseWrite-capable connection automatically — winio''s dial returns a message-byte pipe whenever the server''s pipe is message type.

## Verified live

- `echo x | docker run -i --rm alpine cat` → returns `x` (was hung); 50-line and multi-line stdin round-trip.
- `docker exec -i <ctr> wc -l` → correct count (was hung).
- `docker build` with a 2MB context → builds fine (large half-closed request body intact).
- version / run / pull unaffected.

New e2e stage **StdinPipeIntoContainer** pipes multi-line input through `run -i cat` and `exec -i wc -l` with a bounded timeout, so a regression fails instead of hanging the suite. **Full 18-stage acceptance green under message mode** — every existing path (hello-world, bind mounts, exec, logs -f, compose build, migrate, idle, interrupt, vsock, Desktop-intact) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)